### PR TITLE
fix(engine): default move_top count to 1 when omitted

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -42,7 +42,7 @@ export async function move_top(
   const p = (action as any).payload ?? {};
   const from_zone: string = String(p.from_zone ?? "");
   const to_zone: string   = String(p.to_zone   ?? "");
-  const count: number     = p.count === null ? 1 : Number(p.count);
+  const count: number     = p.count == null ? 1 : Number(p.count);
 
   // 基本字段校验
   if (!from_zone || !to_zone) {

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -104,11 +104,11 @@ describe('engine.step', () => {
 		expect(r.error?.code).toBe('ILLEGAL_ACTION');
 	});
 
-	// 场景五：move_top 成功移动指定数量的实体
-	// compiled_spec 路径：通过解释器执行 effect_pipeline
-	it('move_top should move N items from source to target when valid (compiled path)', async () => {
-		const dsl = buildValidDSL();
-		const compiled = await compile({ dsl });
+        // 场景五：move_top 成功移动指定数量的实体
+        // compiled_spec 路径：通过解释器执行 effect_pipeline
+        it('move_top should move N items from source to target when valid (compiled path)', async () => {
+                const dsl = buildValidDSL();
+                const compiled = await compile({ dsl });
 		const seats = ['A', 'B'];
 		const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
 
@@ -122,6 +122,24 @@ describe('engine.step', () => {
 		const ns: any = r.next_state!;
 		expect(ns.zones.deck.instances['A'].items.length).toBe(0);
 		expect(ns.zones.hand.instances['A'].items.length).toBe(2);
-		expect(new Set(ns.zones.hand.instances['A'].items)).toEqual(new Set(['c1','c2']));
-	});
+                expect(new Set(ns.zones.hand.instances['A'].items)).toEqual(new Set(['c1','c2']));
+        });
+
+        // 场景六：move_top 缺省 count 时默认为 1
+        it('move_top defaults count to 1 when omitted', async () => {
+                const dsl = buildValidDSL();
+                const compiled = await compile({ dsl });
+                const seats = ['A', 'B'];
+                const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+
+                const gs: any = base.game_state;
+                gs.zones.deck.instances['A'].items = ['c1'];
+                gs.zones.hand.instances['A'].items = [];
+
+                const r = await step({ game_state: gs, action: { id: 'move_top', by: 'A', payload: { from_zone: 'deck', to_zone: 'hand' }, seq: 1 } });
+                expect(r.ok).toBe(true);
+                const ns: any = r.next_state!;
+                expect(ns.zones.deck.instances['A'].items).toEqual([]);
+                expect(ns.zones.hand.instances['A'].items).toEqual(['c1']);
+        });
 });


### PR DESCRIPTION
## Summary
- handle missing `count` in `move_top` action by defaulting to 1
- add regression test for default `move_top` behavior

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a526a70928832bbfccf1d6bab79580