### PR TITLE
Handle undefined count in move_top action

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -42,7 +42,7 @@ export async function move_top(
   const p = (action as any).payload ?? {};
   const from_zone: string = String(p.from_zone ?? "");
   const to_zone: string   = String(p.to_zone   ?? "");
-  const count: number     = p.count === null ? 1 : Number(p.count);
+  const count: number     = p.count == null ? 1 : Number(p.count);
 
   // 基本字段校验
   if (!from_zone || !to_zone) {

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -104,24 +104,45 @@ describe('engine.step', () => {
 		expect(r.error?.code).toBe('ILLEGAL_ACTION');
 	});
 
-	// 场景五：move_top 成功移动指定数量的实体
-	// compiled_spec 路径：通过解释器执行 effect_pipeline
-	it('move_top should move N items from source to target when valid (compiled path)', async () => {
-		const dsl = buildValidDSL();
-		const compiled = await compile({ dsl });
-		const seats = ['A', 'B'];
-		const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+       // 场景五：move_top 成功移动指定数量的实体
+       // compiled_spec 路径：通过解释器执行 effect_pipeline
+       it('move_top should move N items from source to target when valid (compiled path)', async () => {
+               const dsl = buildValidDSL();
+               const compiled = await compile({ dsl });
+               const seats = ['A', 'B'];
+               const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
 
-		// seed source items
-		const gs: any = base.game_state;
-		gs.zones.deck.instances['A'].items = ['c1', 'c2'];
-		gs.zones.hand.instances['A'].items = [];
+               // seed source items
+               const gs: any = base.game_state;
+               gs.zones.deck.instances['A'].items = ['c1', 'c2'];
+               gs.zones.hand.instances['A'].items = [];
 
-		const r = await step({ compiled_spec: compiled.compiled_spec!, game_state: gs, action: { id: 'draw', by: 'A', payload: { count: 2 }, seq: 1 } });
-		expect(r.ok).toBe(true);
-		const ns: any = r.next_state!;
-		expect(ns.zones.deck.instances['A'].items.length).toBe(0);
-		expect(ns.zones.hand.instances['A'].items.length).toBe(2);
-		expect(new Set(ns.zones.hand.instances['A'].items)).toEqual(new Set(['c1','c2']));
-	});
+               const r = await step({ compiled_spec: compiled.compiled_spec!, game_state: gs, action: { id: 'draw', by: 'A', payload: { count: 2 }, seq: 1 } });
+               expect(r.ok).toBe(true);
+               const ns: any = r.next_state!;
+               expect(ns.zones.deck.instances['A'].items.length).toBe(0);
+               expect(ns.zones.hand.instances['A'].items.length).toBe(2);
+               expect(new Set(ns.zones.hand.instances['A'].items)).toEqual(new Set(['c1','c2']));
+       });
+
+       // 场景六：move_top 省略 count 时默认移动 1 张
+       it('move_top should default count to 1 when omitted (fallback path)', async () => {
+               const dsl = buildValidDSL();
+               const compiled = await compile({ dsl });
+               const seats = ['A', 'B'];
+               const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+
+               const gs: any = base.game_state;
+               gs.zones.deck.instances['A'].items = ['c1', 'c2'];
+               gs.zones.hand.instances['A'].items = [];
+
+               const r = await step({
+                       game_state: gs,
+                       action: { id: 'move_top', by: 'A', payload: { from_zone: 'deck', to_zone: 'hand' }, seq: 1 }
+               });
+               expect(r.ok).toBe(true);
+               const ns: any = r.next_state!;
+               expect(ns.zones.deck.instances['A'].items).toEqual(['c1']);
+               expect(ns.zones.hand.instances['A'].items).toEqual(['c2']);
+       });
 });


### PR DESCRIPTION
## Summary
- Allow `move_top` to treat missing `count` as 1 by default
- Test fallback path where `count` is omitted

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a52814ee60832b86ef51f60f33f555