### PR TITLE
feat: add auto runner victory logic

### DIFF
--- a/src/engine/auto_runner.test.ts
+++ b/src/engine/auto_runner.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from '../compiler/index';
+import { auto_runner } from './auto_runner';
+
+function buildDSL(result: string) {
+  return {
+    schema_version: 0,
+    engine_compat: '>=1.0.0',
+    id: 'demo',
+    name: 'Demo Game',
+    metadata: { seats: { min: 2, max: 2, default: 2 } },
+    entities: [],
+    zones: [],
+    phases: [ { id: 'main', transitions: [] } ],
+    actions: [ { id: 'noop', effect: [] } ],
+    victory: { order: [ { when: true, result } ] },
+  };
+}
+
+describe('auto_runner victory handling', () => {
+  it('counts wins', async () => {
+    const dsl = buildDSL('win');
+    const compiled = await compile({ dsl });
+    expect(compiled.ok).toBe(true);
+    const summary = await auto_runner({ compiled_spec: compiled.compiled_spec!, seats: ['A','B'], episodes: 1, max_steps: 5 });
+    expect(summary.wins).toBe(1);
+    expect(summary.losses).toBe(0);
+    expect(summary.ties).toBe(0);
+  });
+
+  it('counts losses', async () => {
+    const dsl = buildDSL('loss');
+    const compiled = await compile({ dsl });
+    expect(compiled.ok).toBe(true);
+    const summary = await auto_runner({ compiled_spec: compiled.compiled_spec!, seats: ['A','B'], episodes: 1, max_steps: 5 });
+    expect(summary.losses).toBe(1);
+    expect(summary.wins).toBe(0);
+    expect(summary.ties).toBe(0);
+  });
+
+  it('counts ties when no victory', async () => {
+    const dsl = {
+      schema_version: 0,
+      engine_compat: '>=1.0.0',
+      id: 'demo',
+      name: 'Demo Game',
+      metadata: { seats: { min: 2, max: 2, default: 2 } },
+      entities: [],
+      zones: [],
+      phases: [ { id: 'main', transitions: [] } ],
+      actions: [ { id: 'noop', effect: [] } ],
+      victory: { order: [ { when: false, result: 'ongoing' } ] },
+    };
+    const compiled = await compile({ dsl });
+    expect(compiled.ok).toBe(true);
+    const summary = await auto_runner({ compiled_spec: compiled.compiled_spec!, seats: ['A','B'], episodes: 1, max_steps: 1 });
+    expect(summary.ties).toBe(1);
+    expect(summary.wins).toBe(0);
+    expect(summary.losses).toBe(0);
+  });
+});
+

--- a/src/engine/auto_runner.ts
+++ b/src/engine/auto_runner.ts
@@ -1,0 +1,69 @@
+import { initial_state, step } from './index';
+import type { CompiledSpecType } from '../schema';
+import type { GameState } from '../types';
+
+export interface AutoRunnerOptions {
+  compiled_spec: CompiledSpecType;
+  seats: string[];
+  episodes: number;
+  max_steps?: number;
+}
+
+export interface AutoRunnerSummary {
+  episodes: number;
+  steps: number;
+  ties: number;
+  wins: number;
+  losses: number;
+}
+
+function evalVictory(compiled_spec: CompiledSpecType, state: GameState): string {
+  const chain = compiled_spec.victory?.order || [];
+  for (const { when, result } of chain) {
+    // 支持布尔或 { const: boolean } 占位
+    const cond = typeof when === 'object' && when !== null && 'const' in (when as any)
+      ? (when as any).const
+      : when;
+    if (cond) return result;
+  }
+  return 'ongoing';
+}
+
+/**
+ * 简单的自动运行器：循环执行 "noop" 动作并在每步后检查胜负。
+ * 若 victory 表达式返回 win/loss/tie 则提前结束该局。
+ */
+export async function auto_runner(opts: AutoRunnerOptions): Promise<AutoRunnerSummary> {
+  const { compiled_spec, seats, episodes, max_steps = 100 } = opts;
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  let steps = 0;
+
+  for (let ep = 0; ep < episodes; ep++) {
+    const init = await initial_state({ compiled_spec, seats, seed: ep });
+    let state = init.game_state;
+    for (let i = 0; i < max_steps; i++) {
+      const action = {
+        id: 'noop',
+        by: state.active_seat || '',
+        payload: {},
+        seq: state.meta.last_seq + 1,
+      };
+      const r = await step({ compiled_spec, game_state: state, action });
+      if (!r.ok || !r.next_state) {
+        ties++;
+        break;
+      }
+      state = r.next_state;
+      steps++;
+      const result = evalVictory(compiled_spec, state);
+      if (result === 'win') { wins++; break; }
+      if (result === 'loss') { losses++; break; }
+      if (result === 'tie') { ties++; break; }
+      if (i === max_steps - 1) ties++;
+    }
+  }
+
+  return { episodes, steps, ties, wins, losses };
+}


### PR DESCRIPTION
## Summary
- add auto runner for iterative game execution
- track compiled victory results and count wins/losses/ties
- add tests for auto_runner victory outcomes

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a52d9b9608832bbb1c922c6f62db16