### PR TITLE
feat: add strategy support to auto runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Patch Changes
 
 - test
+- add strategy support to auto_runner

--- a/src/engine/auto_runner.test.ts
+++ b/src/engine/auto_runner.test.ts
@@ -26,6 +26,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.wins).toBe(1);
     expect(summary.losses).toBe(0);
     expect(summary.ties).toBe(0);
+    expect(summary.no_actions).toBe(0);
   });
 
   it('counts losses', async () => {
@@ -36,6 +37,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.losses).toBe(1);
     expect(summary.wins).toBe(0);
     expect(summary.ties).toBe(0);
+    expect(summary.no_actions).toBe(0);
   });
 
   it('counts ties when no victory', async () => {
@@ -57,6 +59,6 @@ describe('auto_runner victory handling', () => {
     expect(summary.ties).toBe(1);
     expect(summary.wins).toBe(0);
     expect(summary.losses).toBe(0);
+    expect(summary.no_actions).toBe(1);
   });
 });
-

--- a/src/engine/auto_runner.ts
+++ b/src/engine/auto_runner.ts
@@ -1,12 +1,16 @@
 import { initial_state, step } from './index';
 import type { CompiledSpecType } from '../schema';
 import type { GameState } from '../types';
+import { legal_actions_compiled } from './legal_actions_compiled';
+import type { Strategy } from './strategy';
+import { firstStrategy } from './strategy';
 
 export interface AutoRunnerOptions {
   compiled_spec: CompiledSpecType;
   seats: string[];
   episodes: number;
   max_steps?: number;
+  strategies?: Record<string, Strategy> | Strategy[];
 }
 
 export interface AutoRunnerSummary {
@@ -15,12 +19,12 @@ export interface AutoRunnerSummary {
   ties: number;
   wins: number;
   losses: number;
+  no_actions: number;
 }
 
 function evalVictory(compiled_spec: CompiledSpecType, state: GameState): string {
   const chain = compiled_spec.victory?.order || [];
   for (const { when, result } of chain) {
-    // 支持布尔或 { const: boolean } 占位
     const cond = typeof when === 'object' && when !== null && 'const' in (when as any)
       ? (when as any).const
       : when;
@@ -29,35 +33,50 @@ function evalVictory(compiled_spec: CompiledSpecType, state: GameState): string 
   return 'ongoing';
 }
 
+function getStrategy(strategies: AutoRunnerOptions['strategies'], seat: string, seats: string[]): Strategy {
+  if (Array.isArray(strategies)) {
+    const idx = seats.indexOf(seat);
+    return strategies[idx] || firstStrategy;
+  }
+  if (strategies && seat in strategies) return strategies[seat];
+  return firstStrategy;
+}
+
 /**
- * 简单的自动运行器：循环执行 "noop" 动作并在每步后检查胜负。
- * 若 victory 表达式返回 win/loss/tie 则提前结束该局。
+ * 基于策略的自动运行器：
+ * - 每步通过 legal_actions_compiled 枚举候选行动
+ * - 根据席位对应的 Strategy 选择下一步
+ * - 无候选或 Strategy 返回 null 时结束该局，计为平局/无行动
  */
 export async function auto_runner(opts: AutoRunnerOptions): Promise<AutoRunnerSummary> {
-  const { compiled_spec, seats, episodes, max_steps = 100 } = opts;
+  const { compiled_spec, seats, episodes, max_steps = 100, strategies } = opts;
   let wins = 0;
   let losses = 0;
   let ties = 0;
   let steps = 0;
+  let no_actions = 0;
 
   for (let ep = 0; ep < episodes; ep++) {
     const init = await initial_state({ compiled_spec, seats, seed: ep });
     let state = init.game_state;
+    let result = evalVictory(compiled_spec, state);
+    if (result === 'win') { wins++; continue; }
+    if (result === 'loss') { losses++; continue; }
+    if (result === 'tie') { ties++; continue; }
+
     for (let i = 0; i < max_steps; i++) {
-      const action = {
-        id: 'noop',
-        by: state.active_seat || '',
-        payload: {},
-        seq: state.meta.last_seq + 1,
-      };
+      const seat = state.active_seat || '';
+      const calls = legal_actions_compiled({ compiled_spec: compiled_spec as any, game_state: state, by: seat, seats });
+      const strat = getStrategy(strategies, seat, seats);
+      const next = strat.choose(calls, { seat, state });
+      if (!next) { ties++; no_actions++; break; }
+
+      const action = { id: next.action, by: next.by, payload: next.payload || {}, seq: state.meta.last_seq + 1 };
       const r = await step({ compiled_spec, game_state: state, action });
-      if (!r.ok || !r.next_state) {
-        ties++;
-        break;
-      }
+      if (!r.ok || !r.next_state) { ties++; break; }
       state = r.next_state;
       steps++;
-      const result = evalVictory(compiled_spec, state);
+      result = evalVictory(compiled_spec, state);
       if (result === 'win') { wins++; break; }
       if (result === 'loss') { losses++; break; }
       if (result === 'tie') { ties++; break; }
@@ -65,5 +84,5 @@ export async function auto_runner(opts: AutoRunnerOptions): Promise<AutoRunnerSu
     }
   }
 
-  return { episodes, steps, ties, wins, losses };
+  return { episodes, steps, ties, wins, losses, no_actions };
 }

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -1,0 +1,25 @@
+import type { GameState } from '../types';
+import type { ActionCall } from './legal_actions_compiled';
+
+export interface StrategyContext {
+  seat: string;
+  state: GameState;
+}
+
+export interface Strategy {
+  choose(actionCalls: ActionCall[], ctx: StrategyContext): ActionCall | null;
+}
+
+export const firstStrategy: Strategy = {
+  choose(actionCalls) {
+    return actionCalls[0] ?? null;
+  },
+};
+
+export const randomStrategy: Strategy = {
+  choose(actionCalls) {
+    if (actionCalls.length === 0) return null;
+    const idx = Math.floor(Math.random() * actionCalls.length);
+    return actionCalls[idx];
+  },
+};


### PR DESCRIPTION
## Summary
- add Strategy interface with basic implementations
- allow AutoRunner to use per-seat strategies and pick legal actions
- track no-action episodes in AutoRunnerSummary

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a54148dd88832bacb08da1e6fb897d