### PR TITLE
feat(engine): add strategy modules and tests

### DIFF
--- a/src/engine/auto_runner.ts
+++ b/src/engine/auto_runner.ts
@@ -3,7 +3,7 @@ import type { CompiledSpecType } from '../schema';
 import type { GameState } from '../types';
 import { legal_actions_compiled } from './legal_actions_compiled';
 import type { Strategy } from './strategy';
-import { firstStrategy } from './strategy';
+import { firstStrategy } from './strategies';
 
 export interface AutoRunnerOptions {
   compiled_spec: CompiledSpecType;

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -215,3 +215,6 @@ export async function step(input: StepInput): Promise<StepOutput> {
     error: err("UNKNOWN_ACTION", `action '${action.id}' not implemented`)
   };
 }
+
+export type { Strategy, StrategyContext } from './strategy';
+export { firstStrategy, randomStrategy } from './strategies';

--- a/src/engine/strategies/first-strategy.ts
+++ b/src/engine/strategies/first-strategy.ts
@@ -1,0 +1,7 @@
+import type { Strategy } from '../strategy';
+
+export const firstStrategy: Strategy = {
+  choose(actionCalls) {
+    return actionCalls[0] ?? null;
+  },
+};

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -1,0 +1,2 @@
+export { firstStrategy } from './first-strategy';
+export { randomStrategy } from './random-strategy';

--- a/src/engine/strategies/random-strategy.ts
+++ b/src/engine/strategies/random-strategy.ts
@@ -1,0 +1,9 @@
+import type { Strategy } from '../strategy';
+
+export const randomStrategy: Strategy = {
+  choose(actionCalls) {
+    if (actionCalls.length === 0) return null;
+    const idx = Math.floor(Math.random() * actionCalls.length);
+    return actionCalls[idx];
+  },
+};

--- a/src/engine/strategy.test.ts
+++ b/src/engine/strategy.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from '../compiler/index';
+import { initial_state } from './index';
+import { legal_actions_compiled } from './legal_actions_compiled';
+import { firstStrategy, randomStrategy } from './strategies';
+import type { Strategy } from './strategy';
+
+function buildDSL() {
+  return {
+    schema_version: 0,
+    engine_compat: '>=1.0.0',
+    id: 'demo',
+    name: 'Demo Game',
+    metadata: { seats: { min: 1, max: 1, default: 1 } },
+    entities: [ { id: 'card', props: {} } ],
+    zones: [
+      { id: 'deck', kind: 'stack', scope: 'per_seat', of: ['card'], visibility: 'owner' },
+      { id: 'hand', kind: 'list', scope: 'per_seat', of: ['card'], visibility: 'owner' },
+    ],
+    phases: [ { id: 'main', transitions: [] } ],
+    actions: [
+      { id: 'drawA', effect: [ { op: 'move_top', from_zone: 'deck', to_zone: 'hand' } ] },
+      { id: 'drawB', effect: [ { op: 'move_top', from_zone: 'deck', to_zone: 'hand' } ] },
+    ],
+    victory: { order: [ { when: true, result: 'ongoing' } ] },
+  };
+}
+
+describe('built-in strategies', () => {
+  it('firstStrategy picks the first legal action', async () => {
+    const compiled = await compile({ dsl: buildDSL() });
+    expect(compiled.ok).toBe(true);
+    const init = await initial_state({ compiled_spec: compiled.compiled_spec!, seats: ['A'], seed: 1 });
+    const gs: any = init.game_state;
+    gs.zones.deck.instances['A'].items = ['c1'];
+    const calls = legal_actions_compiled({ compiled_spec: compiled.compiled_spec!, game_state: gs, by: 'A', seats: ['A'] });
+    expect(calls.length).toBe(2);
+    const strat: Strategy = firstStrategy;
+    const chosen = strat.choose(calls, { seat: 'A', state: gs });
+    expect(chosen).toEqual(calls[0]);
+  });
+
+  it('randomStrategy returns one of the legal actions or null on empty input', async () => {
+    const compiled = await compile({ dsl: buildDSL() });
+    const init = await initial_state({ compiled_spec: compiled.compiled_spec!, seats: ['A'], seed: 1 });
+    const gs: any = init.game_state;
+    gs.zones.deck.instances['A'].items = ['c1'];
+    const calls = legal_actions_compiled({ compiled_spec: compiled.compiled_spec!, game_state: gs, by: 'A', seats: ['A'] });
+    const chosen = randomStrategy.choose(calls, { seat: 'A', state: gs });
+    expect(calls.includes(chosen!)).toBe(true);
+    expect(randomStrategy.choose([], { seat: 'A', state: gs })).toBeNull();
+    expect(firstStrategy.choose([], { seat: 'A', state: gs })).toBeNull();
+  });
+});

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -9,17 +9,3 @@ export interface StrategyContext {
 export interface Strategy {
   choose(actionCalls: ActionCall[], ctx: StrategyContext): ActionCall | null;
 }
-
-export const firstStrategy: Strategy = {
-  choose(actionCalls) {
-    return actionCalls[0] ?? null;
-  },
-};
-
-export const randomStrategy: Strategy = {
-  choose(actionCalls) {
-    if (actionCalls.length === 0) return null;
-    const idx = Math.floor(Math.random() * actionCalls.length);
-    return actionCalls[idx];
-  },
-};


### PR DESCRIPTION
## Summary
- extract strategy interface and move first/random strategies into dedicated modules
- re-export built-in strategies and integrate with auto_runner default
- add unit tests verifying strategy behaviors with legal_actions_compiled

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a544dff400832bb6fde61e0948668e