### PR TITLE
feat: track no action and violations in auto runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 - test
 - add strategy support to auto_runner
+- track `no_action` episodes and `violations` in auto_runner summary

--- a/src/engine/auto_runner.strategy.test.ts
+++ b/src/engine/auto_runner.strategy.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { compile } from '../compiler/index';
+import type { Strategy } from './strategy';
+
+vi.mock('./legal_actions_compiled', () => ({
+  legal_actions_compiled: () => [ { action: 'noop', by: 'A', payload: {} } ]
+}));
+
+import { auto_runner } from './auto_runner';
+
+function buildDSL() {
+  return {
+    schema_version: 0,
+    engine_compat: '>=1.0.0',
+    id: 'demo',
+    name: 'Demo Game',
+    metadata: { seats: { min: 2, max: 2, default: 2 } },
+    entities: [],
+    zones: [],
+    phases: [ { id: 'main', transitions: [] } ],
+    actions: [ { id: 'noop', effect: [] } ],
+    victory: { order: [ { when: false, result: 'ongoing' } ] },
+  };
+}
+
+describe('auto_runner strategy behaviors', () => {
+  it('records no_action when strategy returns null', async () => {
+    const dsl = buildDSL();
+    const compiled = await compile({ dsl });
+    const nullStrat: Strategy = { choose: () => null };
+    const summary = await auto_runner({ compiled_spec: compiled.compiled_spec!, seats: ['A','B'], episodes: 1, strategies: { A: nullStrat }, max_steps: 5 });
+    expect(summary.no_action).toBe(1);
+    expect(summary.ties).toBe(1);
+    expect(summary.violations).toBe(0);
+  });
+
+  it('records violations when strategy throws', async () => {
+    const dsl = buildDSL();
+    const compiled = await compile({ dsl });
+    const badStrat: Strategy = { choose: () => { throw new Error('boom'); } };
+    const summary = await auto_runner({ compiled_spec: compiled.compiled_spec!, seats: ['A','B'], episodes: 1, strategies: { A: badStrat }, max_steps: 5 });
+    expect(summary.violations).toBe(1);
+    expect(summary.no_action).toBe(0);
+    expect(summary.ties).toBe(0);
+  });
+});

--- a/src/engine/auto_runner.test.ts
+++ b/src/engine/auto_runner.test.ts
@@ -26,7 +26,8 @@ describe('auto_runner victory handling', () => {
     expect(summary.wins).toBe(1);
     expect(summary.losses).toBe(0);
     expect(summary.ties).toBe(0);
-    expect(summary.no_actions).toBe(0);
+    expect(summary.no_action).toBe(0);
+    expect(summary.violations).toBe(0);
   });
 
   it('counts losses', async () => {
@@ -37,7 +38,8 @@ describe('auto_runner victory handling', () => {
     expect(summary.losses).toBe(1);
     expect(summary.wins).toBe(0);
     expect(summary.ties).toBe(0);
-    expect(summary.no_actions).toBe(0);
+    expect(summary.no_action).toBe(0);
+    expect(summary.violations).toBe(0);
   });
 
   it('counts ties when no victory', async () => {
@@ -59,6 +61,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.ties).toBe(1);
     expect(summary.wins).toBe(0);
     expect(summary.losses).toBe(0);
-    expect(summary.no_actions).toBe(1);
+    expect(summary.no_action).toBe(1);
+    expect(summary.violations).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- track episodes with no legal actions or null strategies via `no_action`
- capture strategy exceptions as `violations`
- document new fields and add tests for null return and errors

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Strings must use singlequote)*

------
https://chatgpt.com/codex/tasks/task_e_68a56f6baaac832ba91e8025799b2446