### PR TITLE
feat: add coverage metrics to auto_runner

### DIFF
--- a/src/engine/auto_runner.strategy.test.ts
+++ b/src/engine/auto_runner.strategy.test.ts
@@ -32,6 +32,8 @@ describe('auto_runner strategy behaviors', () => {
     expect(summary.no_action).toBe(1);
     expect(summary.ties).toBe(1);
     expect(summary.violations).toBe(0);
+    expect(summary.branch_hits.ongoing).toBe(1);
+    expect(summary.action_hits.noop).toBeUndefined();
   });
 
   it('records violations when strategy throws', async () => {
@@ -42,5 +44,7 @@ describe('auto_runner strategy behaviors', () => {
     expect(summary.violations).toBe(1);
     expect(summary.no_action).toBe(0);
     expect(summary.ties).toBe(0);
+    expect(summary.branch_hits.ongoing).toBe(1);
+    expect(summary.action_hits.noop).toBeUndefined();
   });
 });

--- a/src/engine/auto_runner.test.ts
+++ b/src/engine/auto_runner.test.ts
@@ -28,6 +28,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.ties).toBe(0);
     expect(summary.no_action).toBe(0);
     expect(summary.violations).toBe(0);
+    expect(summary.branch_hits.win).toBe(1);
   });
 
   it('counts losses', async () => {
@@ -40,6 +41,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.ties).toBe(0);
     expect(summary.no_action).toBe(0);
     expect(summary.violations).toBe(0);
+    expect(summary.branch_hits.loss).toBe(1);
   });
 
   it('counts ties when no victory', async () => {
@@ -63,5 +65,6 @@ describe('auto_runner victory handling', () => {
     expect(summary.losses).toBe(0);
     expect(summary.no_action).toBe(1);
     expect(summary.violations).toBe(0);
+    expect(summary.branch_hits.ongoing).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- track executed actions and victory branches in auto_runner
- expose action and branch hit counts in AutoRunnerSummary
- test coverage metrics for auto runner behavior

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a571a90148832b8a091e34a6990961