### PR TITLE
feat: add max steps limit to auto runner

### DIFF
--- a/src/engine/auto_runner.test.ts
+++ b/src/engine/auto_runner.test.ts
@@ -29,6 +29,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.no_action).toBe(0);
     expect(summary.violations).toBe(0);
     expect(summary.branch_hits.win).toBe(1);
+    expect(summary.episode_steps[0]).toBe(0);
   });
 
   it('counts losses', async () => {
@@ -42,6 +43,7 @@ describe('auto_runner victory handling', () => {
     expect(summary.no_action).toBe(0);
     expect(summary.violations).toBe(0);
     expect(summary.branch_hits.loss).toBe(1);
+    expect(summary.episode_steps[0]).toBe(0);
   });
 
   it('counts ties when no victory', async () => {
@@ -66,5 +68,6 @@ describe('auto_runner victory handling', () => {
     expect(summary.no_action).toBe(1);
     expect(summary.violations).toBe(0);
     expect(summary.branch_hits.ongoing).toBe(1);
+    expect(summary.episode_steps[0]).toBe(0);
   });
 });

--- a/src/engine/parallel_auto_runner.ts
+++ b/src/engine/parallel_auto_runner.ts
@@ -53,6 +53,7 @@ export async function parallel_auto_runner(opts: ParallelAutoRunnerOptions): Pro
     violations: 0,
     action_hits: {},
     branch_hits: {},
+    episode_steps: [],
   } as AutoRunnerSummary;
   const trajectories: Event[][] = [];
   for (const r of results) {
@@ -63,6 +64,7 @@ export async function parallel_auto_runner(opts: ParallelAutoRunnerOptions): Pro
     summary.losses += r.losses;
     summary.no_action += r.no_action;
     summary.violations += r.violations;
+    summary.episode_steps.push(...r.episode_steps);
     for (const [k, v] of Object.entries(r.action_hits)) {
       summary.action_hits[k] = (summary.action_hits[k] || 0) + v;
     }


### PR DESCRIPTION
## Summary
- add `max_steps` option to auto runner with default upper limit
- track steps per episode and mark tie on exceeding limit
- include episode step counts in summaries and parallel runner aggregation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59061fda8832b9b57156e817429c9