### PR TITLE
feat: evaluate action requirements

### DIFF
--- a/src/engine/helpers/expr.util.ts
+++ b/src/engine/helpers/expr.util.ts
@@ -1,0 +1,23 @@
+import type { InterpreterCtx } from '../effects/types';
+
+/**
+ * Evaluate a DSL expression AST. Placeholder implementation
+ * supports booleans or objects in the shape of `{ const: any }`.
+ * Other shapes default to `true`.
+ */
+export function eval_expr(ast: unknown, _ctx: InterpreterCtx): any {
+  if (typeof ast === 'boolean') return ast;
+  if (ast && typeof ast === 'object' && 'const' in (ast as any)) {
+    return (ast as any).const;
+  }
+  // TODO: hook up real expression evaluator
+  return true;
+}
+
+/**
+ * Convenience wrapper to coerce the result of `eval_expr`
+ * into a boolean.
+ */
+export function eval_condition(ast: unknown, ctx: InterpreterCtx): boolean {
+  return Boolean(eval_expr(ast, ctx));
+}


### PR DESCRIPTION
## Summary
- add placeholder expression evaluator
- validate action `require_ast` before running pipeline
- test error path when requirement fails

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a67d93d390832bae7d16ff384f1516