### PR TITLE
feat: add shuffle, deal and set_var ops

### DIFF
--- a/src/compiler/effects.ts
+++ b/src/compiler/effects.ts
@@ -9,19 +9,42 @@ type MoveTopNode = {
   count: number;
 };
 
-const Supported_Effect_Op = ['move_top'];
+type ShuffleNode = {
+  op: 'shuffle';
+  zone: string;
+  owner: 'by' | 'active' | string;
+};
+
+type DealNode = {
+  op: 'deal';
+  from_zone: string;
+  to_zone: string;
+  from_owner: 'by' | 'active' | string;
+  to_owner: 'by' | 'active' | 'seat' | string;
+  count: number;
+};
+
+type SetVarNode = {
+  op: 'set_var';
+  key: string;
+  value: unknown;
+};
+
+type EffectNode = MoveTopNode | ShuffleNode | DealNode | SetVarNode;
+
+const Supported_Effect_Op = ['move_top', 'shuffle', 'deal', 'set_var'];
 
 export function normalize_effect_pipeline(
   raw: unknown,
   zones_index: CompiledSpecType['zones_index'],
   add_issue: (_code: string, _path: string, _msg: string) => void
-): MoveTopNode[] | null {
+): EffectNode[] | null {
   if (!Array.isArray(raw)) {
     add_issue('SCHEMA_ERROR', '/actions/*/effect', 'effect 必须是一个数组');
     return null;
   }
 
-  const out: MoveTopNode[] = [];
+  const out: EffectNode[] = [];
 
   for (let i = 0; i < raw.length; i++) {
     const node = raw[i] as any;
@@ -65,7 +88,54 @@ export function normalize_effect_pipeline(
         count
       });
     }
-    
+    else if (node.op === 'shuffle') {
+      const zone = String(node.zone ?? "");
+      const owner = (node.owner ?? 'by') as ShuffleNode['owner'];
+      if (!zone) {
+        add_issue('SCHEMA_ERROR', `/actions/*/effect/${i}`, 'zone is required');
+        return null;
+      }
+      const z = zones_index[zone];
+      if (!z) add_issue('REF_NOT_FOUND', `/actions/*/effect/${i}/zone`, `zone '${zone}' not found`);
+      const supported = (k: string) => k === 'list' || k === 'stack' || k === 'queue';
+      if (z && !supported(z.kind)) add_issue('KIND_UNSUPPORTED', `/actions/*/effect/${i}/zone`, `kind '${z.kind}' not supported by shuffle`);
+      out.push({ op: 'shuffle', zone, owner });
+    }
+    else if (node.op === 'deal') {
+      const from_zone = String(node.from_zone ?? "");
+      const to_zone   = String(node.to_zone ?? "");
+      const from_owner = (node.from_owner ?? 'by') as DealNode['from_owner'];
+      const to_owner   = (node.to_owner   ?? 'seat') as DealNode['to_owner'];
+      const count      = node.count == null ? 1 : Number(node.count);
+
+      if (!from_zone || !to_zone) {
+        add_issue('SCHEMA_ERROR', `/actions/*/effect/${i}`, 'from_zone/to_zone is required');
+        return null;
+      }
+      if (!Number.isInteger(count) || count <= 0) {
+        add_issue('SCHEMA_ERROR', `/actions/*/effect/${i}/count`, 'count must be positive integer');
+        return null;
+      }
+
+      const zFrom = zones_index[from_zone];
+      const zTo   = zones_index[to_zone];
+      if (!zFrom) add_issue('REF_NOT_FOUND', `/actions/*/effect/${i}/from_zone`, `zone '${from_zone}' not found`);
+      if (!zTo)   add_issue('REF_NOT_FOUND', `/actions/*/effect/${i}/to_zone`, `zone '${to_zone}' not found`);
+      const supported = (k: string) => k === 'list' || k === 'stack' || k === 'queue';
+      if (zFrom && !supported(zFrom.kind)) add_issue('KIND_UNSUPPORTED', `/actions/*/effect/${i}/from_zone`, `kind '${zFrom.kind}' not supported by deal`);
+      if (zTo   && !supported(zTo.kind))   add_issue('KIND_UNSUPPORTED', `/actions/*/effect/${i}/to_zone`,   `kind '${zTo.kind}' not supported by deal`);
+
+      out.push({ op: 'deal', from_zone, to_zone, from_owner, to_owner, count });
+    }
+    else if (node.op === 'set_var') {
+      const key = String(node.key ?? "");
+      if (!key) {
+        add_issue('SCHEMA_ERROR', `/actions/*/effect/${i}`, 'key is required');
+        return null;
+      }
+      out.push({ op: 'set_var', key, value: node.value });
+    }
+
   }
 
   return out;

--- a/src/engine/effects/deal.ts
+++ b/src/engine/effects/deal.ts
@@ -1,0 +1,33 @@
+import type { EffectExecutor } from './types';
+import { resolve_owner } from '../helpers/owner.util';
+import { apply_move_top } from '../helpers/zones.util';
+
+export type DealOp = {
+  op: 'deal';
+  from_zone: string;
+  to_zone: string;
+  from_owner: 'by' | 'active' | string;
+  to_owner: 'by' | 'active' | 'seat' | string;
+  count?: number;
+};
+
+export const exec_deal: EffectExecutor<DealOp> = (op, ctx) => {
+  const count = typeof op.count === 'number' ? op.count : 1;
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`deal.count 非法：${count}`);
+  }
+  const from_owner = resolve_owner(op.from_owner, ctx);
+  let state = ctx.state;
+  const seats = ctx.state.seats;
+  for (const seat of seats) {
+    const to_owner = op.to_owner === 'seat' ? seat : resolve_owner(op.to_owner, ctx);
+    state = apply_move_top(state, {
+      from_zone: op.from_zone,
+      to_zone: op.to_zone,
+      from_owner,
+      to_owner,
+      count,
+    });
+  }
+  return state;
+};

--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -1,10 +1,16 @@
 import { exec_move_top, type MoveTopOp } from './move_top';
+import { exec_shuffle, type ShuffleOp } from './shuffle';
+import { exec_deal, type DealOp } from './deal';
+import { exec_set_var, type SetVarOp } from './set_var';
 import type { EffectExecutor } from './types';
 
-export type EffectOp = MoveTopOp; // 后续并入更多 op
+export type EffectOp = MoveTopOp | ShuffleOp | DealOp | SetVarOp;
 
 export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
   move_top: exec_move_top,
+  shuffle: exec_shuffle,
+  deal: exec_deal,
+  set_var: exec_set_var,
 };
 
 

--- a/src/engine/effects/set_var.ts
+++ b/src/engine/effects/set_var.ts
@@ -1,0 +1,14 @@
+import type { EffectExecutor } from './types';
+
+export type SetVarOp = {
+  op: 'set_var';
+  key: string;
+  value: unknown;
+};
+
+export const exec_set_var: EffectExecutor<SetVarOp> = (op, ctx) => {
+  return {
+    ...ctx.state,
+    vars: { ...ctx.state.vars, [op.key]: op.value },
+  } as any;
+};

--- a/src/engine/effects/shuffle.ts
+++ b/src/engine/effects/shuffle.ts
@@ -1,0 +1,34 @@
+import type { EffectExecutor } from './types';
+import { resolve_owner } from '../helpers/owner.util';
+import { mulberry32 } from '../../utils/rng.util';
+
+export type ShuffleOp = {
+  op: 'shuffle';
+  zone: string;
+  owner: 'by' | 'active' | string;
+};
+
+export const exec_shuffle: EffectExecutor<ShuffleOp> = (op, ctx) => {
+  const owner = resolve_owner(op.owner, ctx);
+  const zone: any = ctx.state.zones[op.zone];
+  if (!zone) throw new Error(`zone '${op.zone}' not found`);
+  const inst = zone.instances?.[owner];
+  if (!inst || !Array.isArray(inst.items)) {
+    throw new Error(`owner '${owner}' not found in zone '${op.zone}'`);
+  }
+  const rng = mulberry32(Number(ctx.state.rng_state || 0));
+  const items = [...inst.items];
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = rng.next_uint32() % (i + 1);
+    const tmp = items[i];
+    items[i] = items[j];
+    items[j] = tmp;
+  }
+  const nextZone = { ...zone, instances: { ...zone.instances } };
+  nextZone.instances[owner] = { ...inst, items };
+  return {
+    ...ctx.state,
+    zones: { ...ctx.state.zones, [op.zone]: nextZone },
+    rng_state: String(rng.state >>> 0),
+  } as any;
+};


### PR DESCRIPTION
## Summary
- support shuffle, deal and set_var effect ops in compiler and engine
- execute new ops and enumerate actions including them
- test shuffle/deal/set_var workflows

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a68347e398832bbd312e5f02fd9cb9