### PR TITLE
feat: basic expression evaluator

### DIFF
--- a/src/engine/helpers/expr.util.test.ts
+++ b/src/engine/helpers/expr.util.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { eval_expr, eval_condition } from './expr.util';
+import type { InterpreterCtx } from '../effects/types';
+
+const ctx: InterpreterCtx = {
+  compiled: {} as any,
+  state: { vars: { score: 5 }, active_seat: 'A' } as any,
+  call: { action: 'dummy', by: 'A', payload: { count: 3 } }
+};
+
+describe('eval_expr', () => {
+  it('resolves constants and variables', () => {
+    expect(eval_expr({ const: 1 }, ctx)).toBe(1);
+    expect(eval_expr({ var: 'payload.count' }, ctx)).toBe(3);
+    expect(eval_expr({ var: 'state.vars.score' }, ctx)).toBe(5);
+  });
+
+  it('supports arithmetic and comparison', () => {
+    const ast = { op: '>', args: [ { op: '+', args: [ { var: 'payload.count' }, { const: 1 } ] }, { const: 3 } ] };
+    expect(eval_expr(ast, ctx)).toBe(true);
+  });
+
+  it('supports logical combination and eval_condition', () => {
+    const ast = {
+      op: 'and',
+      args: [
+        { op: '>', args: [ { var: 'payload.count' }, { const: 1 } ] },
+        { op: '<', args: [ { var: 'payload.count' }, { const: 5 } ] }
+      ]
+    };
+    expect(eval_expr(ast, ctx)).toBe(true);
+
+    const ast2 = { op: 'or', args: [ { const: false }, { op: 'not', args: [ { const: false } ] } ] };
+    expect(eval_condition(ast2, ctx)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- evaluate expression AST supporting variables, arithmetic, comparison and logic
- use new evaluator for conditional checks
- add tests for common expression cases

## Testing
- `pnpm test`
- `pnpm lint` *(fails: no-unused-vars, import/order, quotes, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a692cc279c832b8d62d1938121882e