### PR TITLE
feat: parse setup plan and init decks

### DIFF
--- a/src/compiler/initializers.ts
+++ b/src/compiler/initializers.ts
@@ -1,0 +1,99 @@
+import type { CompiledSpecType } from '../schema';
+
+export type InitSpawn = {
+  op: 'spawn';
+  entity: string;
+  to_zone: string;
+  owner: 'seat' | 'by' | 'active' | string;
+  count: number;
+  props?: Record<string, unknown>;
+};
+
+export type InitShuffle = {
+  op: 'shuffle';
+  zone: string;
+  owner: 'seat' | 'by' | 'active' | string;
+};
+
+export type InitDeal = {
+  op: 'deal';
+  from_zone: string;
+  to_zone: string;
+  from_owner: 'seat' | 'by' | 'active' | string;
+  to_owner: 'seat' | 'by' | 'active' | string;
+  count: number;
+};
+
+export type InitOp = InitSpawn | InitShuffle | InitDeal;
+
+export function normalize_initializer_plan(
+  raw: unknown,
+  zones_index: CompiledSpecType['zones_index'],
+  entities_index: Record<string, any>,
+  add_issue: (code: string, path: string, msg: string) => void
+): InitOp[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    add_issue('SCHEMA_ERROR', '/setup', 'setup must be an array');
+    return [];
+  }
+
+  const out: InitOp[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    const node = raw[i] as any;
+    if (!node || typeof node !== 'object') {
+      add_issue('SCHEMA_ERROR', `/setup/${i}`, 'node must be object');
+      continue;
+    }
+    if (node.op === 'spawn') {
+      const to_zone = String(node.to_zone ?? '');
+      const entity = String(node.entity ?? '');
+      const owner = (node.owner ?? 'seat') as InitSpawn['owner'];
+      const count = node.count == null ? 1 : Number(node.count);
+      if (!to_zone || !entity) {
+        add_issue('SCHEMA_ERROR', `/setup/${i}`, 'to_zone and entity are required');
+        continue;
+      }
+      const z = zones_index[to_zone];
+      if (!z) add_issue('REF_NOT_FOUND', `/setup/${i}/to_zone`, `zone '${to_zone}' not found`);
+      if (!entities_index[entity])
+        add_issue('REF_NOT_FOUND', `/setup/${i}/entity`, `entity '${entity}' not found`);
+      if (!Number.isInteger(count) || count <= 0)
+        add_issue('SCHEMA_ERROR', `/setup/${i}/count`, 'count must be positive integer');
+      out.push({ op: 'spawn', entity, to_zone, owner, count, props: node.props });
+    } else if (node.op === 'shuffle') {
+      const zone = String(node.zone ?? '');
+      const owner = (node.owner ?? 'seat') as InitShuffle['owner'];
+      if (!zone) {
+        add_issue('SCHEMA_ERROR', `/setup/${i}`, 'zone is required');
+        continue;
+      }
+      const z = zones_index[zone];
+      if (!z) add_issue('REF_NOT_FOUND', `/setup/${i}/zone`, `zone '${zone}' not found`);
+      out.push({ op: 'shuffle', zone, owner });
+    } else if (node.op === 'deal') {
+      const from_zone = String(node.from_zone ?? '');
+      const to_zone = String(node.to_zone ?? '');
+      const from_owner = (node.from_owner ?? 'seat') as InitDeal['from_owner'];
+      const to_owner = (node.to_owner ?? 'seat') as InitDeal['to_owner'];
+      const count = node.count == null ? 1 : Number(node.count);
+      if (!from_zone || !to_zone) {
+        add_issue('SCHEMA_ERROR', `/setup/${i}`, 'from_zone and to_zone are required');
+        continue;
+      }
+      const zFrom = zones_index[from_zone];
+      const zTo = zones_index[to_zone];
+      if (!zFrom) add_issue('REF_NOT_FOUND', `/setup/${i}/from_zone`, `zone '${from_zone}' not found`);
+      if (!zTo) add_issue('REF_NOT_FOUND', `/setup/${i}/to_zone`, `zone '${to_zone}' not found`);
+      if (!Number.isInteger(count) || count <= 0)
+        add_issue('SCHEMA_ERROR', `/setup/${i}/count`, 'count must be positive integer');
+      out.push({ op: 'deal', from_zone, to_zone, from_owner, to_owner, count });
+    } else {
+      add_issue('EFFECT_UNSUPPORTED', `/setup/${i}`, `unsupported op '${node.op}'`);
+    }
+  }
+
+  return out;
+}
+

--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -2,15 +2,17 @@ import { exec_move_top, type MoveTopOp } from './move_top';
 import { exec_shuffle, type ShuffleOp } from './shuffle';
 import { exec_deal, type DealOp } from './deal';
 import { exec_set_var, type SetVarOp } from './set_var';
+import { exec_spawn, type SpawnOp } from './spawn';
 import type { EffectExecutor } from './types';
 
-export type EffectOp = MoveTopOp | ShuffleOp | DealOp | SetVarOp;
+export type EffectOp = MoveTopOp | ShuffleOp | DealOp | SetVarOp | SpawnOp;
 
 export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
   move_top: exec_move_top,
   shuffle: exec_shuffle,
   deal: exec_deal,
   set_var: exec_set_var,
+  spawn: exec_spawn,
 };
 
 

--- a/src/engine/effects/shuffle.ts
+++ b/src/engine/effects/shuffle.ts
@@ -5,30 +5,34 @@ import { mulberry32 } from '../../utils/rng.util';
 export type ShuffleOp = {
   op: 'shuffle';
   zone: string;
-  owner: 'by' | 'active' | string;
+  owner: 'by' | 'active' | 'seat' | string;
 };
 
 export const exec_shuffle: EffectExecutor<ShuffleOp> = (op, ctx) => {
-  const owner = resolve_owner(op.owner, ctx);
-  const zone: any = ctx.state.zones[op.zone];
-  if (!zone) throw new Error(`zone '${op.zone}' not found`);
-  const inst = zone.instances?.[owner];
-  if (!inst || !Array.isArray(inst.items)) {
-    throw new Error(`owner '${owner}' not found in zone '${op.zone}'`);
+  const owners = op.owner === 'seat' ? ctx.state.seats : [resolve_owner(op.owner, ctx)];
+  let state = ctx.state;
+  for (const owner of owners) {
+    const zone: any = state.zones[op.zone];
+    if (!zone) throw new Error(`zone '${op.zone}' not found`);
+    const inst = zone.instances?.[owner];
+    if (!inst || !Array.isArray(inst.items)) {
+      throw new Error(`owner '${owner}' not found in zone '${op.zone}'`);
+    }
+    const rng = mulberry32(Number(state.rng_state || 0));
+    const items = [...inst.items];
+    for (let i = items.length - 1; i > 0; i--) {
+      const j = rng.next_uint32() % (i + 1);
+      const tmp = items[i];
+      items[i] = items[j];
+      items[j] = tmp;
+    }
+    const nextZone = { ...zone, instances: { ...zone.instances } };
+    nextZone.instances[owner] = { ...inst, items };
+    state = {
+      ...state,
+      zones: { ...state.zones, [op.zone]: nextZone },
+      rng_state: String(rng.state >>> 0),
+    } as any;
   }
-  const rng = mulberry32(Number(ctx.state.rng_state || 0));
-  const items = [...inst.items];
-  for (let i = items.length - 1; i > 0; i--) {
-    const j = rng.next_uint32() % (i + 1);
-    const tmp = items[i];
-    items[i] = items[j];
-    items[j] = tmp;
-  }
-  const nextZone = { ...zone, instances: { ...zone.instances } };
-  nextZone.instances[owner] = { ...inst, items };
-  return {
-    ...ctx.state,
-    zones: { ...ctx.state.zones, [op.zone]: nextZone },
-    rng_state: String(rng.state >>> 0),
-  } as any;
+  return state;
 };

--- a/src/engine/effects/spawn.ts
+++ b/src/engine/effects/spawn.ts
@@ -1,0 +1,48 @@
+import type { EffectExecutor } from './types';
+import { resolve_owner } from '../helpers/owner.util';
+
+export type SpawnOp = {
+  op: 'spawn';
+  entity: string;
+  to_zone: string;
+  owner: 'seat' | 'by' | 'active' | string;
+  count?: number;
+  props?: Record<string, unknown>;
+};
+
+export const exec_spawn: EffectExecutor<SpawnOp> = (op, ctx) => {
+  const count = typeof op.count === 'number' ? op.count : 1;
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`spawn.count 非法：${count}`);
+  }
+  const owners = op.owner === 'seat' ? ctx.state.seats : [resolve_owner(op.owner, ctx)];
+  let state = ctx.state;
+  let eidCounter = Object.keys(state.entities).length;
+  for (const owner of owners) {
+    const zone: any = state.zones[op.to_zone];
+    if (!zone) throw new Error(`zone '${op.to_zone}' not found`);
+    const inst = zone.instances?.[owner];
+    if (!inst || !Array.isArray(inst.items)) {
+      throw new Error(`owner '${owner}' not found in zone '${op.to_zone}'`);
+    }
+    const cap: number | undefined = zone.capacity;
+    if (typeof cap === 'number' && inst.items.length + count > cap) {
+      throw new Error(`would exceed capacity ${cap}`);
+    }
+    const items = [...inst.items];
+    const entities = { ...state.entities } as any;
+    for (let i = 0; i < count; i++) {
+      const eid = `e${++eidCounter}`;
+      entities[eid] = { entity_type: op.entity, props: { ...(op.props || {}) } };
+      items.push(eid);
+    }
+    const nextZone = { ...zone, instances: { ...zone.instances, [owner]: { ...inst, items } } };
+    state = {
+      ...state,
+      entities,
+      zones: { ...state.zones, [op.to_zone]: nextZone },
+    } as any;
+  }
+  return state;
+};
+

--- a/src/schema/compiled-spec.schema.ts
+++ b/src/schema/compiled-spec.schema.ts
@@ -25,10 +25,12 @@ export const CompiledSpec = z.object({
    * 初始化计划：
    * - plan：初始化指令序列（spawn/shuffle/deal/...）
    * - seed_vars：写入 game_state.vars 的初始变量
+   * - seed_per_seat：写入 game_state.per_seat[seat] 的初始变量
    */
   initializers: z.object({
     plan: z.array(z.any()),
     seed_vars: z.record(z.string(), z.any()),
+    seed_per_seat: z.record(z.string(), z.any()),
   }),
 
   /**


### PR DESCRIPTION
## Summary
- parse DSL state/setup into initializer plan and seed variables
- add spawn/shuffle/deal execution during initial state construction
- test deck and hand initialization via setup plan

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a7313409f4832b93dad090af2047d9