### PR TITLE
feat: add trigger execution

### DIFF
--- a/src/engine/__test__/triggers.test.ts
+++ b/src/engine/__test__/triggers.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+
+import { compile } from '../../compiler/index';
+import { initial_state } from '../index';
+import { step_compiled } from '../step_compiled';
+
+function dslWithDraw() {
+  return {
+    schema_version: 0,
+    engine_compat: '>=1.0.0',
+    id: 'demo',
+    name: 'Demo Game',
+    metadata: { seats: { min: 2, max: 4, default: 2 } },
+    entities: [{ id: 'card', props: { cost: 1 } }],
+    zones: [
+      { id: 'deck', kind: 'stack', scope: 'per_seat', of: ['card'], visibility: 'owner', capacity: 60 },
+      { id: 'hand', kind: 'list', scope: 'per_seat', of: ['card'], visibility: 'owner' },
+    ],
+    phases: [{ id: 'main', transitions: [] }],
+    actions: [
+      { id: 'draw', effect: [{ op: 'move_top', from_zone: 'deck', to_zone: 'hand', count: 1 }] },
+    ],
+    victory: { order: [{ when: true, result: 'ongoing' }] },
+  };
+}
+
+async function build() {
+  const compiled = await compile({ dsl: dslWithDraw() });
+  expect(compiled.ok).toBe(true);
+  const seats = ['A', 'B'];
+  const init = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+  return { compiled_spec: compiled.compiled_spec!, init } as const;
+}
+
+describe('triggers', () => {
+  it('runs after:draw triggers', async () => {
+    const { compiled_spec, init } = await build();
+    (compiled_spec as any).triggers_index['after:draw'] = [
+      [{ op: 'set_var', key: 't1', value: 1 }],
+      [{ op: 'set_var', key: 't2', value: 2 }],
+    ];
+    const gs: any = init.game_state;
+    gs.zones.deck.instances['A'].items = ['c1'];
+    gs.zones.hand.instances['A'].items = [];
+    const { next_state } = step_compiled({
+      compiled_spec,
+      game_state: gs,
+      action: { action: 'draw', by: 'A', payload: {} },
+    });
+    const ns: any = next_state as any;
+    expect(ns.vars.t1).toBe(1);
+    expect(ns.vars.t2).toBe(2);
+  });
+});

--- a/src/engine/triggers.ts
+++ b/src/engine/triggers.ts
@@ -1,0 +1,36 @@
+import type { GameState, ReduceContext } from '../types';
+import type { CompiledSpecType } from '../schema';
+import { effectExecutors, type EffectOp } from './effects';
+import type { CompiledActionCall, InterpreterCtx } from './effects/types';
+
+/**
+ * 根据触发 key 执行效果管线。
+ *
+ * 编译产物中的 triggers_index 按触发 key 存放一组效果管线，每条管线为一系列原子效果。
+ */
+export function run_triggers(args: {
+  compiled_spec: CompiledSpecType;
+  game_state: GameState;
+  trigger_key: string;
+  call: CompiledActionCall;
+  context?: ReduceContext;
+}): GameState {
+  const { compiled_spec, game_state, trigger_key, call, context } = args;
+  const pipelines = ((compiled_spec as any).triggers_index ?? {})[trigger_key] as Array<any> | undefined;
+  if (!pipelines || pipelines.length === 0) return game_state;
+
+  let state = game_state;
+  const ctx: InterpreterCtx = { compiled: compiled_spec, state, call, context };
+
+  for (const pipeline of pipelines) {
+    const ops = Array.isArray(pipeline) ? pipeline : [pipeline];
+    for (const op of ops) {
+      const exec = effectExecutors[op.op as EffectOp['op']];
+      if (!exec) throw new Error(`不支持的 op: ${(op as any).op}`);
+      ctx.state = state;
+      state = exec(op as any, ctx);
+    }
+  }
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- add trigger runner to execute pipelines keyed by trigger name
- run triggers after main action pipeline in step interpreter
- test trigger execution after draw action

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js'; after installing, lint reports multiple errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7361e83f0832bb6afd04293c14bb5