### PR TITLE
feat(engine): expose victory evaluation

### DIFF
--- a/src/engine/__test__/engine.test.ts
+++ b/src/engine/__test__/engine.test.ts
@@ -97,6 +97,29 @@ describe('engine.initial_state', () => {
 });
 
 describe('engine.step', () => {
+        // 场景一：若达成终局应在 StepOutput 返回 victory
+        it('should return victory result when game ends', async () => {
+                const dsl = {
+                        schema_version: 0,
+                        engine_compat: '>=1.0.0',
+                        id: 'demo',
+                        name: 'Demo Game',
+                        metadata: { seats: { min: 2, max: 2, default: 2 } },
+                        entities: [],
+                        zones: [],
+                        phases: [ { id: 'main', transitions: [] } ],
+                        actions: [ { id: 'noop', effect: [] } ],
+                        victory: { order: [ { when: true, result: 'win' } ] },
+                } as const;
+                const compiled = await compile({ dsl });
+                expect(compiled.ok).toBe(true);
+                const seats = ['A','B'];
+                const base = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+                const r = await step({ compiled_spec: compiled.compiled_spec!, game_state: base.game_state, action: { id: 'noop', by: 'A', payload: {}, seq: 1 } });
+                expect(r.ok).toBe(true);
+                expect(r.victory).toBe('win');
+        });
+
 // 场景二：end_turn 推进席位并在未环回时不自增回合
 it('end_turn should advance active seat and keep turn unless wrapped (compiled fallback path)', async () => {
 const dsl = buildValidDSL();

--- a/src/engine/auto_runner.ts
+++ b/src/engine/auto_runner.ts
@@ -3,7 +3,7 @@
  * 在给定规则与策略下批量模拟对局，产出胜负/平局、步数、
  * 无法行动次数、策略违规次数、命中统计与可选事件轨迹等。
  */
-import { initial_state, step } from './index';
+import { initial_state, step, eval_victory } from './index';
 import type { CompiledSpecType } from '../schema';
 import type { GameState, Event } from '../types';
 import { ActionCall, CompiledLike, legal_actions_compiled } from './legal_actions_compiled';
@@ -49,25 +49,6 @@ export interface AutoRunnerSummary {
   trajectories?: Event[][];
 }
 
-/**
- * 评估胜负：按 `compiled_spec.victory.order` 顺序判定，
- * 命中则返回对应结果并记录分支；否则返回 'ongoing'。
- */
-function eval_victory(compiled_spec: CompiledSpecType, state: GameState, hit?: (key: string) => void): string {
-  const chain = compiled_spec.victory?.order || [];
-  for (const { when, result } of chain) {
-    // DSL 可能将条件编译为 { const: boolean }
-    const cond = typeof when === 'object' && when !== null && 'const' in (when as any)
-      ? (when as any).const
-      : when;
-    if (cond) {
-      hit?.(String(result));
-      return result;
-    }
-  }
-  hit?.('ongoing');
-  return 'ongoing';
-}
 
 /**
  * 为指定席位选择策略：

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { compile } from './compiler';
-export { initial_state, step } from './engine';
+export { initial_state, step, eval_victory } from './engine';
 export { auto_runner } from './engine/auto_runner';
 export { legal_actions_compiled } from './engine/legal_actions_compiled';
 export type * from './types';

--- a/src/types/step.type.ts
+++ b/src/types/step.type.ts
@@ -65,4 +65,6 @@ export interface StepOutput {
    * 失败时可为空（实现也可选择回传当前 state 的哈希，非必需）。
    */
   state_hash?: string;
+  /** 游戏胜负结果（若非 ongoing 则返回，如 'win'/'loss'/'tie'） */
+  victory?: string;
 }


### PR DESCRIPTION
## Summary
- expose reusable `eval_victory` helper
- include victory result in `step` output
- cover victory evaluation in engine tests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js' ... many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a738feb638832ba5208fc2ed25a3d9