### PR TITLE
feat: add spawn and destroy effects

### DIFF
--- a/src/compiler/compile.test.ts
+++ b/src/compiler/compile.test.ts
@@ -106,13 +106,15 @@ describe('compile', () => {
         });
 
         // 场景四：规范化新 effect op（shuffle/deal/set_var）
-        it('should normalize shuffle/deal/set_var ops', async () => {
+        it('should normalize shuffle/deal/set_var/spawn/destroy ops', async () => {
                 const dsl = buildValidDSL();
                 dsl.actions.push(
                         { id: 'shuf', effect: [ { op: 'shuffle', zone: 'deck' } ] },
                         { id: 'deal', effect: [ { op: 'deal', from_zone: 'deck', to_zone: 'hand', to_owner: 'seat', count: 1 } ] },
                         { id: 'setv', effect: [ { op: 'set_var', key: 'foo', value: 42 } ] },
                         { id: 'phase', effect: [ { op: 'set_phase', phase: 'main' } ] },
+                        { id: 'spawn', effect: [ { op: 'spawn', entity: 'card', to_zone: 'hand' } ] },
+                        { id: 'kill', effect: [ { op: 'destroy', from_zone: 'hand', count: 1 } ] },
                 );
                 const result = await compile({ dsl });
                 expect(result.ok).toBe(true);
@@ -128,6 +130,12 @@ describe('compile', () => {
                 ]);
                 expect(compiled.actions_index['phase'].effect_pipeline).toEqual([
                         { op: 'set_phase', phase: 'main' }
+                ]);
+                expect(compiled.actions_index['spawn'].effect_pipeline).toEqual([
+                        { op: 'spawn', entity: 'card', to_zone: 'hand', owner: 'by', count: 1, props: undefined }
+                ]);
+                expect(compiled.actions_index['kill'].effect_pipeline).toEqual([
+                        { op: 'destroy', from_zone: 'hand', owner: 'by', count: 1 }
                 ]);
         });
 });

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -68,6 +68,7 @@ export async function compile(input: CompileInput): Promise<CompileOutput> {
     const pipeline = normalize_effect_pipeline(
       a.effect ?? [],          // 没写 effect 就当空管线
       zones_index,
+      entities_index,
       addIssue
     );
 

--- a/src/engine/effects/destroy.ts
+++ b/src/engine/effects/destroy.ts
@@ -1,0 +1,43 @@
+import type { EffectExecutor } from './types';
+import { resolve_owner } from '../helpers/owner.util';
+
+export type DestroyOp = {
+  op: 'destroy';
+  from_zone: string;
+  owner: 'seat' | 'by' | 'active' | string;
+  count?: number;
+};
+
+export const exec_destroy: EffectExecutor<DestroyOp> = (op, ctx) => {
+  const count = typeof op.count === 'number' ? op.count : 1;
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`destroy.count 非法：${count}`);
+  }
+  const owners = op.owner === 'seat' ? ctx.state.seats : [resolve_owner(op.owner, ctx)];
+  let state = ctx.state;
+  for (const owner of owners) {
+    const zone: any = state.zones[op.from_zone];
+    if (!zone) throw new Error(`zone '${op.from_zone}' not found`);
+    const inst = zone.instances?.[owner];
+    if (!inst || !Array.isArray(inst.items)) {
+      throw new Error(`owner '${owner}' not found in zone '${op.from_zone}'`);
+    }
+    if (inst.items.length < count) {
+      throw new Error(`need ${count}, have ${inst.items.length}`);
+    }
+    const items = [...inst.items];
+    const entities = { ...state.entities } as any;
+    for (let i = 0; i < count; i++) {
+      const eid = items.pop();
+      if (eid) delete entities[eid];
+    }
+    const nextZone = { ...zone, instances: { ...zone.instances, [owner]: { ...inst, items } } };
+    state = {
+      ...state,
+      entities,
+      zones: { ...state.zones, [op.from_zone]: nextZone },
+    } as any;
+  }
+  return state;
+};
+

--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -3,6 +3,7 @@ import { exec_shuffle, type ShuffleOp } from './shuffle';
 import { exec_deal, type DealOp } from './deal';
 import { exec_set_var, type SetVarOp } from './set_var';
 import { exec_spawn, type SpawnOp } from './spawn';
+import { exec_destroy, type DestroyOp } from './destroy';
 import { exec_set_phase, type SetPhaseOp } from './set_phase';
 import type { EffectExecutor } from './types';
 
@@ -12,6 +13,7 @@ export type EffectOp =
   | DealOp
   | SetVarOp
   | SpawnOp
+  | DestroyOp
   | SetPhaseOp;
 
 export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
@@ -20,6 +22,7 @@ export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
   deal: exec_deal,
   set_var: exec_set_var,
   spawn: exec_spawn,
+  destroy: exec_destroy,
   set_phase: exec_set_phase,
 };
 

--- a/src/engine/effects/spawn.ts
+++ b/src/engine/effects/spawn.ts
@@ -17,7 +17,7 @@ export const exec_spawn: EffectExecutor<SpawnOp> = (op, ctx) => {
   }
   const owners = op.owner === 'seat' ? ctx.state.seats : [resolve_owner(op.owner, ctx)];
   let state = ctx.state;
-  let eidCounter = Object.keys(state.entities).length;
+  let eidCounter = state.meta?.next_eid || 1;
   for (const owner of owners) {
     const zone: any = state.zones[op.to_zone];
     if (!zone) throw new Error(`zone '${op.to_zone}' not found`);
@@ -41,6 +41,7 @@ export const exec_spawn: EffectExecutor<SpawnOp> = (op, ctx) => {
       ...state,
       entities,
       zones: { ...state.zones, [op.to_zone]: nextZone },
+      meta: { ...state.meta, next_eid: eidCounter },
     } as any;
   }
   return state;

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -112,7 +112,7 @@ export async function initial_state(input: InitialStateInput): Promise<InitialSt
     rng_state: String(rng.state >>> 0),
 
     // 元信息：包含 schema 版本、创建时间与最后动作序号
-    meta: { schema_version: 1, created_at: now, last_seq: 0 },
+    meta: { schema_version: 1, created_at: now, last_seq: 0, next_eid: 1 },
   };
 
   // 初始化事件（占位一条 "setup"），方便回放/审计

--- a/src/types/game.type.ts
+++ b/src/types/game.type.ts
@@ -16,6 +16,7 @@ export interface GameState {
     schema_version: number;
     created_at?: number;
     last_seq: number;
+    next_eid: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- add spawn and destroy ops to compiler with zone/entity validation
- support runtime spawn/destroy with entity id allocation
- extend legal action inference to handle spawn and destroy
- cover new effects with unit tests

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73b3cf600832bb364dcedf8b214cb