### PR TITLE
feat: add board zone helpers and move_piece effect

### DIFF
--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -5,6 +5,7 @@ import { exec_set_var, type SetVarOp } from './set_var';
 import { exec_spawn, type SpawnOp } from './spawn';
 import { exec_destroy, type DestroyOp } from './destroy';
 import { exec_set_phase, type SetPhaseOp } from './set_phase';
+import { exec_move_piece, type MovePieceOp } from './move_piece';
 import type { EffectExecutor } from './types';
 
 export type EffectOp =
@@ -14,7 +15,8 @@ export type EffectOp =
   | SetVarOp
   | SpawnOp
   | DestroyOp
-  | SetPhaseOp;
+  | SetPhaseOp
+  | MovePieceOp;
 
 export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
   move_top: exec_move_top,
@@ -24,6 +26,7 @@ export const effectExecutors: Record<EffectOp['op'], EffectExecutor<any>> = {
   spawn: exec_spawn,
   destroy: exec_destroy,
   set_phase: exec_set_phase,
+  move_piece: exec_move_piece,
 };
 
 

--- a/src/engine/effects/move_piece.ts
+++ b/src/engine/effects/move_piece.ts
@@ -1,0 +1,21 @@
+import type { EffectExecutor } from './types';
+import { resolve_owner } from '../helpers/owner.util';
+import { apply_move_piece } from '../helpers/zones.util';
+
+export type MovePieceOp = {
+  op: 'move_piece';
+  zone: string;
+  owner: 'by' | 'active' | string;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+};
+
+export const exec_move_piece: EffectExecutor<MovePieceOp> = (op, ctx) => {
+  const owner = resolve_owner(op.owner, ctx);
+  return apply_move_piece(ctx.state, {
+    zone: op.zone,
+    owner,
+    from: op.from,
+    to: op.to,
+  });
+};

--- a/src/engine/helpers/zones.util.test.ts
+++ b/src/engine/helpers/zones.util.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '../../types';
+import { exec_spawn } from '../effects/spawn';
+import { exec_move_piece } from '../effects/move_piece';
+import type { InterpreterCtx } from '../effects/types';
+
+function emptyState(): GameState {
+  return {
+    phase: 'p',
+    turn: 1,
+    seats: ['P1'],
+    active_seat: 'P1',
+    vars: {},
+    per_seat: { P1: {} },
+    entities: {},
+    zones: {
+      board: { kind: 'grid', scope: 'per_seat', of: ['pawn'], instances: { P1: { kind: 'grid', cells: [] } } },
+    } as any,
+    rng_state: '0',
+    meta: { schema_version: 1, last_seq: 0, next_eid: 0 },
+  };
+}
+
+const compiled = { zones_index: { board: { kind: 'grid', scope: 'per_seat', of: ['pawn'] } } } as any;
+
+describe('zones.board helpers', () => {
+  it('spawns and moves piece on grid', () => {
+    let ctx: InterpreterCtx = { compiled, state: emptyState(), call: { action: 'spawn', by: 'P1', payload: {} } };
+    const s1 = exec_spawn({ op: 'spawn', entity: 'pawn', to_zone: 'board', owner: 'by', pos: { x: 0, y: 0 } }, ctx);
+    const eid = s1.zones.board.instances.P1.cells[0][0];
+    expect(eid).toBeDefined();
+    ctx = { ...ctx, state: s1 };
+    const s2 = exec_move_piece({ op: 'move_piece', zone: 'board', owner: 'by', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } }, ctx);
+    expect(s2.zones.board.instances.P1.cells[0]?.[0]).toBeUndefined();
+    expect(s2.zones.board.instances.P1.cells[1][1]).toBe(eid);
+  });
+});

--- a/src/engine/helpers/zones.util.ts
+++ b/src/engine/helpers/zones.util.ts
@@ -65,4 +65,84 @@ export function apply_move_top(state: GameState, params: MoveTopParams): GameSta
   return next;
 }
 
+// --- board helpers ------------------------------------------------------
+
+export type BoardCoord = { x: number; y: number };
+
+function ensure_board(inst: any) {
+  const supported = (k: string) => k === 'grid' || k === 'hexgrid' || k === 'track';
+  if (!supported(inst.kind) || !Array.isArray(inst.cells)) {
+    throw new Error(`zone kind '${inst.kind}' not supported`);
+  }
+}
+
+function clone_cells(cells: string[][]): string[][] {
+  return cells.map((row) => [...row]);
+}
+
+function get_cell(cells: string[][], { x, y }: BoardCoord): string | undefined {
+  return cells[y]?.[x];
+}
+
+function set_cell(cells: string[][], { x, y }: BoardCoord, eid: string | undefined) {
+  if (!cells[y]) cells[y] = [];
+  cells[y][x] = eid as any;
+}
+
+export type SetCellParams = {
+  zone: string;
+  owner: string;
+  coord: BoardCoord;
+  eid: string;
+};
+
+export function apply_set_cell(state: GameState, params: SetCellParams): GameState {
+  const { zone, owner, coord, eid } = params;
+  const zr: any = (state.zones as any)[zone];
+  if (!zr) throw new Error(`zone '${zone}' not found`);
+  const inst = zr.instances?.[owner];
+  if (!inst) throw new Error(`owner '${owner}' not found in zone '${zone}'`);
+  ensure_board(inst);
+
+  const next: GameState = { ...state, zones: { ...state.zones } } as any;
+  const next_zone = { ...zr, instances: { ...zr.instances } };
+  const cells = clone_cells(inst.cells);
+  if (get_cell(cells, coord)) {
+    throw new Error('target cell occupied');
+  }
+  set_cell(cells, coord, eid);
+  next_zone.instances[owner] = { ...inst, cells };
+  (next.zones as any)[zone] = next_zone;
+  return next;
+}
+
+export type MovePieceParams = {
+  zone: string;
+  owner: string;
+  from: BoardCoord;
+  to: BoardCoord;
+};
+
+export function apply_move_piece(state: GameState, params: MovePieceParams): GameState {
+  const { zone, owner, from, to } = params;
+  const zr: any = (state.zones as any)[zone];
+  if (!zr) throw new Error(`zone '${zone}' not found`);
+  const inst = zr.instances?.[owner];
+  if (!inst) throw new Error(`owner '${owner}' not found in zone '${zone}'`);
+  ensure_board(inst);
+
+  const eid = get_cell(inst.cells, from);
+  if (!eid) throw new Error('source cell empty');
+  if (get_cell(inst.cells, to)) throw new Error('target cell occupied');
+
+  const next: GameState = { ...state, zones: { ...state.zones } } as any;
+  const next_zone = { ...zr, instances: { ...zr.instances } };
+  const cells = clone_cells(inst.cells);
+  set_cell(cells, from, undefined);
+  set_cell(cells, to, eid);
+  next_zone.instances[owner] = { ...inst, cells };
+  (next.zones as any)[zone] = next_zone;
+  return next;
+}
+
 


### PR DESCRIPTION
## Summary
- support grid/hexgrid/track board helpers for placing and moving pieces
- allow spawning pieces onto boards and moving them between cells
- add tests covering board piece placement and movement

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73de70e44832ba9a3a9f841128c27