### PR TITLE
feat: simulate effect pipeline in legal_actions

### DIFF
--- a/src/engine/__test__/legal_actions_compiled.test.ts
+++ b/src/engine/__test__/legal_actions_compiled.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from '../../compiler';
+import { initial_state } from '../index';
+import { legal_actions_compiled } from '../legal_actions_compiled';
+
+function dsl() {
+  return {
+    schema_version: 0,
+    engine_compat: '>=1.0.0',
+    id: 'demo',
+    name: 'Demo',
+    metadata: { seats: { min: 2, max: 2, default: 2 } },
+    entities: [ { id: 'card', props: {} } ],
+    zones: [
+      { id: 'deck', kind: 'stack', scope: 'public', of: ['card'], visibility: 'all' },
+      { id: 'hand', kind: 'list', scope: 'per_seat', of: ['card'], visibility: 'owner' },
+    ],
+    phases: [ { id: 'main', transitions: [] } ],
+    actions: [
+      {
+        id: 'double_draw',
+        effect: [
+          { op: 'move_top', from_zone: 'deck', to_zone: 'hand', from_owner: 'by', to_owner: 'by' },
+          { op: 'move_top', from_zone: 'deck', to_zone: 'hand', from_owner: 'by', to_owner: 'by' },
+        ],
+      },
+      {
+        id: 'spawn1_deal',
+        effect: [
+          { op: 'spawn', entity: 'card', to_zone: 'deck', owner: 'by', count: 1 },
+          { op: 'deal', from_zone: 'deck', to_zone: 'hand', from_owner: '_', to_owner: 'seat', count: 1 },
+        ],
+      },
+      {
+        id: 'spawn2_deal',
+        effect: [
+          { op: 'spawn', entity: 'card', to_zone: 'deck', owner: 'by', count: 2 },
+          { op: 'deal', from_zone: 'deck', to_zone: 'hand', from_owner: '_', to_owner: 'seat', count: 1 },
+        ],
+      },
+    ],
+    victory: { order: [ { when: true, result: 'ongoing' } ] },
+  } as const;
+}
+
+describe('legal_actions_compiled pipeline simulation', () => {
+  it('considers resources across multiple steps', async () => {
+    const compiled = await compile({ dsl: dsl() });
+    expect(compiled.ok).toBe(true);
+    const seats = ['A', 'B'];
+    const init = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+    const gs: any = init.game_state;
+
+    gs.zones.deck.instances['_'].items = ['c1'];
+    const calls0 = legal_actions_compiled({ compiled_spec: compiled.compiled_spec!, game_state: gs, by: 'A', seats });
+    expect(calls0.some(c => c.action === 'double_draw')).toBe(false);
+
+    gs.zones.deck.instances['_'].items = ['c1', 'c2'];
+    const calls1 = legal_actions_compiled({ compiled_spec: compiled.compiled_spec!, game_state: gs, by: 'A', seats, maxCountsPerAction: 2 });
+    expect(calls1.some(c => c.action === 'double_draw')).toBe(true);
+  });
+
+  it('takes prior spawn into account for subsequent deal', async () => {
+    const compiled = await compile({ dsl: dsl() });
+    expect(compiled.ok).toBe(true);
+    const seats = ['A', 'B'];
+    const init = await initial_state({ compiled_spec: compiled.compiled_spec!, seats, seed: 1 });
+    const gs: any = init.game_state;
+    gs.zones.deck.instances['_'].items = [];
+    const calls = legal_actions_compiled({ compiled_spec: compiled.compiled_spec!, game_state: gs, by: 'A', seats });
+    expect(calls.some(c => c.action === 'spawn2_deal')).toBe(true);
+    expect(calls.some(c => c.action === 'spawn1_deal')).toBe(false);
+  });
+});
+

--- a/src/engine/legal_actions_compiled.ts
+++ b/src/engine/legal_actions_compiled.ts
@@ -4,60 +4,64 @@
  * 用途：基于编译产物（actions_index + zones_index），在不执行效果的前提下，
  *       静态枚举“可能合法”的动作调用（ActionCall）。
  * 特点：
- *  - 轻量近似：仅分析首个 move_top 节点的资源/容量是否可行；不逐步模拟整条 pipeline。
- *  - 支持 shuffle/deal/set_var 等无资源消耗的 op；若 pipeline 无 move_top，则直接认为可行。
+ *  - 逐步模拟 effect pipeline，动态维护临时资源状态。
+ *  - 支持 move_top / deal / spawn / destroy / shuffle / set_var / set_phase 等 op。
  *  - owner 解析：支持 'by' | 'active' | 'seat'（占位）以及常量 seat_id 字符串。
- *  - count 枚举：生成 1..max 的分支，可通过 maxCountsPerAction 限制规模。
+ *  - count 枚举：生成 1..max 的分支，可通过 maxCountsPerAction 限制规模，并提供 maxBranches 总量限制。
  * 适用：提示 UI、简单 AI、可行性预估；对强一致性要求的合法性，仍需在 step/step_compiled 路径校验。
  */
+
 import { CompiledSpecType } from "../schema";
 import { GameState } from "../types";
 
 type Seats = string[];
-type Scope = 'public' | 'per_seat';
+type Scope = "public" | "per_seat";
 
 type ZoneMeta = {
   scope: Scope;
-  container: 'list' | 'stack' | 'queue' | string;
+  container: "list" | "stack" | "queue" | string;
   capacity?: number | null; // 无/0/undefined 视为无限
 };
 
 type ZonesIndex = Record<string, ZoneMeta>;
 
 type MoveTopOp = {
-  op: 'move_top';
+  op: "move_top";
   from_zone: string;
   to_zone: string;
-  // 与编译器/解释器对齐：既支持占位符，也兼容常量 seat_id 字符串
-  from_owner: 'by' | 'active' | 'seat' | string;
-  to_owner: 'by' | 'active' | 'seat' | string;
+  from_owner: "by" | "active" | "seat" | string;
+  to_owner: "by" | "active" | "seat" | string;
   count?: number;
 };
 
 type SpawnOp = {
-  op: 'spawn';
+  op: "spawn";
   to_zone: string;
-  owner: 'by' | 'active' | 'seat' | string;
+  owner: "by" | "active" | "seat" | string;
   count?: number;
 };
 
 type DestroyOp = {
-  op: 'destroy';
+  op: "destroy";
   from_zone: string;
-  owner: 'by' | 'active' | 'seat' | string;
+  owner: "by" | "active" | "seat" | string;
   count?: number;
 };
-type EffectPipelineOp = { op: 'move_top' | 'shuffle' | 'deal' | 'set_var' | 'spawn' | 'destroy' } & Record<string, unknown>;
+
+type EffectPipelineOp =
+  | ({ op: "move_top" } & MoveTopOp)
+  | ({ op: "spawn" } & SpawnOp)
+  | ({ op: "destroy" } & DestroyOp)
+  | { op: "deal" | "shuffle" | "set_var" | "set_phase"; [key: string]: any };
 
 type EffectDef = {
   action_hash: string;
-  effect_pipeline: EffectPipelineOp[]; // 混合多种 op
+  effect_pipeline: EffectPipelineOp[];
 };
 
 type ActionsIndex = Record<string, EffectDef>;
 
-// 将编译产物收敛为本方法需要的最小形状（并与实际产物字段名对齐：actions_index）
-export type CompiledLike = Pick<CompiledSpecType, 'zones_index' | 'actions_index'> & {
+export type CompiledLike = Pick<CompiledSpecType, "zones_index" | "actions_index"> & {
   zones_index: ZonesIndex;
   actions_index: ActionsIndex;
 };
@@ -68,158 +72,213 @@ export type ActionCall = {
   payload?: Record<string, unknown>;
 };
 
-/**
- * 将 seat 标准化为实例 key：public → '_'；per_seat → seat_id
- */
+/** 将 seat 标准化为实例 key：public → '_'；per_seat → seat_id */
 function inst_key(meta: ZoneMeta, seat: string): string {
-  return meta.scope === 'public' ? '_' : seat;
+  return meta.scope === "public" ? "_" : seat;
 }
 
-/**
- * 读取实例 items 数量（不抛错，缺失视为 0）
- */
+/** 读取实例 items 数量（不抛错，缺失视为 0） */
 function getItemsLen(gs: GameState, zone: string, ownerKey: string): number {
   const items = (gs as any).zones?.[zone]?.instances?.[ownerKey]?.items;
   return Array.isArray(items) ? items.length : 0;
 }
 
-/**
- * 计算实例剩余容量（无限制 → Infinity）
- */
-function capacityLeft(gs: GameState, meta: ZoneMeta, zone: string, ownerKey: string): number {
-  const cap = meta.capacity ?? Infinity;
-  if (!Number.isFinite(cap)) return Infinity;
-  const cur = getItemsLen(gs, zone, ownerKey);
-  return Math.max(0, cap - cur);
+/** 将单个 owner 解析为具体 seat */
+function resolveOwner(
+  mode: "by" | "active" | "seat" | string,
+  by: string,
+  gs: GameState,
+  seat?: string
+): string {
+  if (mode === "by") return by;
+  if (mode === "active") return gs.active_seat || "";
+  if (mode === "seat") return seat || "";
+  return String(mode);
 }
 
-/**
- * owner 候选集合：
- *  - 'by' → [by]
- *  - 'active' → [active_seat]
- *  - 'seat' → 所有 seats（用于生成时枚举，调用时需写入 payload.seat）
- *  - seat_id 字符串 → [seat_id]
- */
-function resolveOwnerCandidates(mode: 'by' | 'active' | 'seat' | string, by: string, gs: GameState, seats: Seats): string[] {
-  if (mode === 'by') return [by];
-  if (mode === 'active') return [gs.active_seat || ''];
-  if (mode === 'seat') return seats;
-  // 常量 seat_id
-  return [String(mode)];
-}
-
-/**
- * 仅支持：所有 op 都是 move_top，且不跨 seat 解析以外的外部条件
- * 对于 count：生成 1..maxCount 的全部分支（可用 options 限制）
- */
+/** 主体：枚举可能合法的动作调用 */
 export function legal_actions_compiled(args: {
   compiled_spec: CompiledLike;
   game_state: GameState;
   by: string;
   seats?: Seats;
-  maxCountsPerAction?: number; // 限制 count 分支，默认生成完整 1..max
-}) : ActionCall[] {
-
+  maxCountsPerAction?: number;
+  maxBranches?: number;
+}): ActionCall[] {
   const { compiled_spec, game_state, by, maxCountsPerAction } = args;
   const seats = args.seats ?? (game_state.seats as Seats);
+  const branchCap =
+    typeof args.maxBranches === "number" && args.maxBranches > 0
+      ? args.maxBranches
+      : Infinity;
 
   const out: ActionCall[] = [];
   const zones = compiled_spec.zones_index;
   const actions = compiled_spec.actions_index;
 
+  const read = (map: Map<string, number>, zone: string, ownerKey: string) => {
+    const k = `${zone}|${ownerKey}`;
+    if (!map.has(k)) map.set(k, getItemsLen(game_state, zone, ownerKey));
+    return map.get(k)!;
+  };
+  const write = (
+    map: Map<string, number>,
+    zone: string,
+    ownerKey: string,
+    val: number
+  ) => {
+    map.set(`${zone}|${ownerKey}`, val);
+  };
+
+  const simulate = (
+    pipeline: EffectPipelineOp[],
+    seat: string | undefined,
+    count: number
+  ): boolean => {
+    const temp = new Map<string, number>();
+    for (const op of pipeline) {
+      if (op.op === "move_top") {
+        const fromMeta = zones[op.from_zone];
+        const toMeta = zones[op.to_zone];
+        if (!fromMeta || !toMeta) return false;
+        const c = typeof op.count === "number" ? op.count : count;
+        const fromOwner = resolveOwner(op.from_owner, by, game_state, seat);
+        const toOwner = resolveOwner(op.to_owner, by, game_state, seat);
+        const fromKey = inst_key(fromMeta, fromOwner);
+        const toKey = inst_key(toMeta, toOwner);
+        if (op.from_zone === op.to_zone && fromKey === toKey) continue;
+        const src = read(temp, op.from_zone, fromKey);
+        const dest = read(temp, op.to_zone, toKey);
+        const cap = toMeta.capacity ?? Infinity;
+        if (src < c) return false;
+        if (dest + c > cap && Number.isFinite(cap)) return false;
+        write(temp, op.from_zone, fromKey, src - c);
+        write(temp, op.to_zone, toKey, dest + c);
+      } else if (op.op === "deal") {
+        const fromMeta = zones[op.from_zone];
+        const toMeta = zones[op.to_zone];
+        if (!fromMeta || !toMeta) return false;
+        const c = typeof op.count === "number" ? op.count : count;
+        const seatIter =
+          op.from_owner === "seat" || op.to_owner === "seat"
+            ? seats
+            : [undefined];
+        for (const s of seatIter) {
+          const fromOwner =
+            op.from_owner === "seat"
+              ? s
+              : resolveOwner(op.from_owner, by, game_state, seat);
+          const toOwner =
+            op.to_owner === "seat"
+              ? s
+              : resolveOwner(op.to_owner, by, game_state, seat);
+          const fromKey = inst_key(fromMeta, fromOwner);
+          const toKey = inst_key(toMeta, toOwner);
+          if (op.from_zone === op.to_zone && fromKey === toKey) continue;
+          const src = read(temp, op.from_zone, fromKey);
+          const dest = read(temp, op.to_zone, toKey);
+          const cap = toMeta.capacity ?? Infinity;
+          if (src < c) return false;
+          if (dest + c > cap && Number.isFinite(cap)) return false;
+          write(temp, op.from_zone, fromKey, src - c);
+          write(temp, op.to_zone, toKey, dest + c);
+        }
+      } else if (op.op === "spawn") {
+        const meta = zones[op.to_zone];
+        if (!meta) return false;
+        const c = typeof op.count === "number" ? op.count : count;
+        const owners =
+          op.owner === "seat"
+            ? [seat]
+            : [resolveOwner(op.owner, by, game_state, seat)];
+        for (const o of owners) {
+          if (!o) return false;
+          const key = inst_key(meta, o);
+          const dest = read(temp, op.to_zone, key);
+          const cap = meta.capacity ?? Infinity;
+          if (dest + c > cap && Number.isFinite(cap)) return false;
+          write(temp, op.to_zone, key, dest + c);
+        }
+      } else if (op.op === "destroy") {
+        const meta = zones[op.from_zone];
+        if (!meta) return false;
+        const c = typeof op.count === "number" ? op.count : count;
+        const owners =
+          op.owner === "seat"
+            ? [seat]
+            : [resolveOwner(op.owner, by, game_state, seat)];
+        for (const o of owners) {
+          if (!o) return false;
+          const key = inst_key(meta, o);
+          const src = read(temp, op.from_zone, key);
+          if (src < c) return false;
+          write(temp, op.from_zone, key, src - c);
+        }
+      } else if (
+        op.op === "shuffle" ||
+        op.op === "set_var" ||
+        op.op === "set_phase"
+      ) {
+        continue;
+      } else {
+        return false;
+      }
+    }
+    return true;
+  };
+
   for (const [name, def] of Object.entries(actions)) {
     const pipeline = def.effect_pipeline;
     if (!Array.isArray(pipeline) || pipeline.length === 0) continue;
 
-    const supported = ['move_top', 'shuffle', 'deal', 'set_var', 'spawn', 'destroy'];
-    if (pipeline.some(op => !supported.includes(op.op))) continue;
+    const supported = [
+      "move_top",
+      "shuffle",
+      "deal",
+      "set_var",
+      "spawn",
+      "destroy",
+      "set_phase",
+    ];
+    if (pipeline.some((op) => !supported.includes(op.op))) continue;
 
-    // 找出首个涉及资源的 op（move_top/spawn/destroy）
-    const first = pipeline.find(op => op.op === 'move_top' || op.op === 'spawn' || op.op === 'destroy') as (MoveTopOp | SpawnOp | DestroyOp | undefined);
-    if (!first) {
-      out.push({ action: name, by });
-      continue;
-    }
+    const needsSeat = pipeline.some(
+      (op) =>
+        (op.op === "move_top" &&
+          (op.from_owner === "seat" || op.to_owner === "seat")) ||
+        (op.op === "spawn" && op.owner === "seat") ||
+        (op.op === "destroy" && op.owner === "seat")
+    );
+    const seatCandidates = needsSeat ? seats : [undefined];
 
-    if (first.op === 'move_top') {
-      const fromMeta = zones[first.from_zone];
-      const toMeta   = zones[first.to_zone];
-      if (!fromMeta || !toMeta) continue;
+    const variableCount = pipeline.some(
+      (op) => typeof (op as any).count !== "number"
+    );
 
-      const fromOwners = resolveOwnerCandidates(first.from_owner as any, by, game_state, seats);
-      const toOwners   = resolveOwnerCandidates(first.to_owner as any, by, game_state, seats);
-
-      for (const fromSeat of fromOwners) {
-        const fromKey = inst_key(fromMeta, fromSeat);
-        const srcLen  = getItemsLen(game_state, first.from_zone, fromKey);
-        if (srcLen <= 0) continue;
-
-        for (const toSeat of toOwners) {
-          const toKey     = inst_key(toMeta, toSeat);
-          const destFree  = capacityLeft(game_state, toMeta, first.to_zone, toKey);
-          let maxCount    = Math.min(srcLen, destFree);
-
-          // 同区同 owner 移动：算 no-op，直接跳过
-          if (first.from_zone === first.to_zone && fromKey === toKey) continue;
-          if (maxCount <= 0) continue;
-
-          const cap = typeof maxCountsPerAction === 'number' && maxCountsPerAction > 0
-            ? Math.min(maxCount, maxCountsPerAction)
-            : maxCount;
-
-          for (let c = 1; c <= cap; c++) {
-            const payload: Record<string, unknown> = { count: c };
-            if (first.from_owner === 'seat') payload.seat = fromSeat;
-            if (first.to_owner === 'seat') payload.seat = toSeat;
-            out.push({ action: name, by, payload });
-          }
+    for (const seat of seatCandidates) {
+      if (!variableCount) {
+        if (simulate(pipeline, seat, 1)) {
+          const payload: Record<string, unknown> = {};
+          if (needsSeat && seat) payload.seat = seat;
+          out.push({ action: name, by, payload });
+          if (out.length >= branchCap) return out;
         }
-      }
-    } else if (first.op === 'spawn') {
-      const meta = zones[first.to_zone];
-      if (!meta) continue;
-
-      const owners = resolveOwnerCandidates(first.owner as any, by, game_state, seats);
-      for (const seat of owners) {
-        const key = inst_key(meta, seat);
-        const destFree = capacityLeft(game_state, meta, first.to_zone, key);
-        let maxCount = destFree;
-        if (!Number.isFinite(maxCount)) maxCount = 1;
-        if (maxCount <= 0) continue;
-
-        const cap = typeof maxCountsPerAction === 'number' && maxCountsPerAction > 0
-          ? Math.min(maxCount, maxCountsPerAction)
-          : maxCount;
-
-        for (let c = 1; c <= cap; c++) {
+      } else {
+        const cap =
+          typeof maxCountsPerAction === "number" && maxCountsPerAction > 0
+            ? maxCountsPerAction
+            : Infinity;
+        for (let c = 1; c <= cap && out.length < branchCap; c++) {
+          if (!simulate(pipeline, seat, c)) break;
           const payload: Record<string, unknown> = { count: c };
-          if (first.owner === 'seat') payload.seat = seat;
+          if (needsSeat && seat) payload.seat = seat;
           out.push({ action: name, by, payload });
         }
-      }
-    } else if (first.op === 'destroy') {
-      const meta = zones[first.from_zone];
-      if (!meta) continue;
-
-      const owners = resolveOwnerCandidates(first.owner as any, by, game_state, seats);
-      for (const seat of owners) {
-        const key = inst_key(meta, seat);
-        const srcLen = getItemsLen(game_state, first.from_zone, key);
-        let maxCount = srcLen;
-        if (maxCount <= 0) continue;
-
-        const cap = typeof maxCountsPerAction === 'number' && maxCountsPerAction > 0
-          ? Math.min(maxCount, maxCountsPerAction)
-          : maxCount;
-
-        for (let c = 1; c <= cap; c++) {
-          const payload: Record<string, unknown> = { count: c };
-          if (first.owner === 'seat') payload.seat = seat;
-          out.push({ action: name, by, payload });
-        }
+        if (out.length >= branchCap) return out;
       }
     }
   }
 
   return out;
 }
+


### PR DESCRIPTION
## Summary
- step-through simulate effect pipelines in legal_actions_compiled and add branch limiting
- test pipeline simulation across multi-step actions

## Testing
- `pnpm test src/engine/__test__/legal_actions_compiled.test.ts`
- `pnpm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a741e30a10832b9f599c54ab14139e