### PR TITLE
feat: add recursive DSL action parser

### DIFF
--- a/src/engine/ast/nodes.ts
+++ b/src/engine/ast/nodes.ts
@@ -22,8 +22,16 @@ export interface BaseNode { kind: NodeKind }
  */
 export interface ActionNode extends BaseNode {
   kind: NodeKind.Action;
+  /** 动作名称或操作符 */
   action: string;
-  args?: ExprNode[];
+  /** 输入规范或参数 */
+  input?: unknown;
+  /** 前置条件表达式 */
+  require?: unknown;
+  /** 子效果（递归的动作节点） */
+  effect?: ActionNode[];
+  /** 其他参数（原样保留以便向后兼容） */
+  props?: Record<string, unknown>;
 }
 
 /**
@@ -106,8 +114,11 @@ export type ASTNode =
  * @param id 动作标识
  * @param args 参数表达式列表
  */
-export function create_action_node(id: string, args: ExprNode[] = []): ActionNode {
-  return { kind: NodeKind.Action, action: id, args };
+export function create_action_node(
+  id: string,
+  props: Record<string, unknown> = {},
+): ActionNode {
+  return { kind: NodeKind.Action, action: id, props };
 }
 
 /**

--- a/src/engine/parser/__test__/parseAction.test.ts
+++ b/src/engine/parser/__test__/parseAction.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseAction } from "../parseAction";
+import { NodeKind } from "../../ast";
+
+describe("parseAction", () => {
+  it("parses nested structures and preserves props", () => {
+    const dsl = {
+      op: "move_top",
+      from_zone: "hand",
+      require: { op: "==", args: [1, 1] },
+      effect: [{ op: "shuffle", zone: "deck" }],
+      input: { type: "number" },
+      extra: { foo: 1 },
+    };
+    const ast = parseAction(dsl);
+    expect(ast).toMatchObject({
+      kind: NodeKind.Action,
+      action: "move_top",
+      require: { op: "==", args: [1, 1] },
+      input: { type: "number" },
+      props: { from_zone: "hand", extra: { foo: 1 } },
+      effect: [
+        { kind: NodeKind.Action, action: "shuffle", props: { zone: "deck" } },
+      ],
+    });
+  });
+
+  it("throws friendly error on non-array effect", () => {
+    const dsl: any = { op: "move_top", effect: {} };
+    expect(() => parseAction(dsl)).toThrow(/effect.*array/);
+  });
+
+  it("throws friendly error on invalid args", () => {
+    const dsl: any = { op: "foo", require: { op: "and", args: 1 } };
+    expect(() => parseAction(dsl)).toThrow(/args must be an array/);
+  });
+
+  it("retains unknown fields like quantifier", () => {
+    const dsl: any = { op: "foo", quantifier: { some: true } };
+    const ast = parseAction(dsl);
+    expect(ast.props?.quantifier).toEqual({ some: true });
+  });
+});

--- a/src/engine/parser/parseAction.ts
+++ b/src/engine/parser/parseAction.ts
@@ -1,0 +1,66 @@
+import { ActionNode, NodeKind } from "../ast";
+
+export interface DslAction {
+  op: string;
+  require?: unknown;
+  effect?: DslAction[];
+  input?: unknown;
+  [key: string]: unknown;
+}
+
+function parseExpr(expr: unknown, path: string): unknown {
+  if (expr === null || typeof expr !== "object") return expr;
+  if (Array.isArray(expr)) {
+    return expr.map((e, i) => parseExpr(e, `${path}/${i}`));
+  }
+  const node: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(expr as Record<string, unknown>)) {
+    if (k === "args") {
+      if (!Array.isArray(v)) {
+        throw new Error(`${path}/args must be an array`);
+      }
+      node[k] = v.map((e, i) => parseExpr(e, `${path}/args/${i}`));
+    } else {
+      node[k] = parseExpr(v, `${path}/${k}`);
+    }
+  }
+  return node;
+}
+
+export function parseAction(dsl: DslAction, path = ""): ActionNode {
+  if (!dsl || typeof dsl !== "object") {
+    throw new Error(`action at '${path || "/"}' must be an object`);
+  }
+  if (typeof dsl.op !== "string" || !dsl.op) {
+    throw new Error(`action at '${path || "/"}' missing op`);
+  }
+
+  const node: ActionNode = { kind: NodeKind.Action, action: dsl.op };
+
+  if ("input" in dsl) {
+    if (dsl.input !== undefined && (typeof dsl.input !== "object" || dsl.input === null)) {
+      throw new Error(`${path}/input must be an object`);
+    }
+    node.input = parseExpr(dsl.input, `${path}/input`);
+  }
+
+  if ("require" in dsl) {
+    node.require = parseExpr(dsl.require, `${path}/require`);
+  }
+
+  if ("effect" in dsl) {
+    if (!Array.isArray(dsl.effect)) {
+      throw new Error(`${path}/effect must be an array`);
+    }
+    node.effect = dsl.effect.map((e, i) => parseAction(e as DslAction, `${path}/effect/${i}`));
+  }
+
+  const props: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(dsl)) {
+    if (k === "op" || k === "require" || k === "effect" || k === "input") continue;
+    props[k] = parseExpr(v, `${path}/${k}`);
+  }
+  if (Object.keys(props).length) node.props = props;
+
+  return node;
+}


### PR DESCRIPTION
## Summary
- extend AST action node to keep require/effect/input and arbitrary props
- add parseAction to recursively parse DSL actions and validate structure
- test valid/invalid DSL parsing cases

## Testing
- `corepack pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2561408c832bb4664b7a22e3c684