### PR TITLE
feat(runtime): add scoped expression evaluator

### DIFF
--- a/src/engine/runtime/__test__/evaluateExpr.test.ts
+++ b/src/engine/runtime/__test__/evaluateExpr.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { create_bind_node, create_comparison_node, create_quantifier_node } from '../../ast';
+import { evaluateExpr, Scope, type EvalContext } from '../index';
+
+function createCtx(state: any): EvalContext {
+  return { state, scope: new Scope() };
+}
+
+describe('evaluateExpr runtime', () => {
+  it('supports variable binding and path resolution with negative index', () => {
+    const state = { vars: { hp: [5, 7, 9] } };
+    const ctx = createCtx(state);
+
+    // bind last hp value to $hp
+    const bind = create_bind_node('$hp', 'state.vars.hp[-1]' as any);
+    evaluateExpr(bind, ctx);
+    expect(ctx.scope.get('$hp')).toBe(9);
+
+    // use bound variable in comparison
+    const cmp = create_comparison_node('==', '$hp' as any, 9 as any);
+    expect(evaluateExpr(cmp, ctx)).toBe(true);
+  });
+
+  it('evaluates quantifiers with local scopes', () => {
+    const state = { nums: [1, 2, 3] };
+    const ctx = createCtx(state);
+    evaluateExpr(create_bind_node('$n', 'state.nums' as any), ctx);
+
+    const exists = create_quantifier_node(
+      'exists',
+      '$n',
+      create_comparison_node('>', '$n' as any, 2 as any),
+    );
+    expect(evaluateExpr(exists, ctx)).toBe(true);
+
+    const forall = create_quantifier_node(
+      'forall',
+      '$n',
+      create_comparison_node('>', '$n' as any, 0 as any),
+    );
+    expect(evaluateExpr(forall, ctx)).toBe(true);
+
+    const forallFail = create_quantifier_node(
+      'forall',
+      '$n',
+      create_comparison_node('>', '$n' as any, 2 as any),
+    );
+    expect(evaluateExpr(forallFail, ctx)).toBe(false);
+
+    // ensure outer binding remains intact
+    expect(ctx.scope.get('$n')).toEqual([1, 2, 3]);
+  });
+});

--- a/src/engine/runtime/evaluate.ts
+++ b/src/engine/runtime/evaluate.ts
@@ -1,0 +1,148 @@
+import { ExprNode, NodeKind } from '../ast';
+import { Scope } from './scope';
+
+export interface EvalContext {
+  state: any;
+  scope: Scope;
+}
+
+function resolvePath(path: string, ctx: EvalContext): unknown {
+  if (!path) return undefined;
+  const parts = path.split('.');
+  if (!parts.length) return undefined;
+
+  let current: any;
+  const first = parts.shift()!;
+  if (first.startsWith('$')) {
+    current = ctx.scope.get(first);
+  } else if (first === 'state') {
+    current = ctx.state;
+  } else {
+    current = ctx.scope.get(first);
+  }
+
+  const indexRegex = /(.*?)\[(.+?)\]/;
+
+  for (const part of parts) {
+    let token = part;
+    let base: any = current;
+    let m: RegExpExecArray | null;
+    // handle nested indices like a[0][1]
+    while ((m = indexRegex.exec(token))) {
+      const prop = m[1];
+      const idxToken = m[2];
+      if (prop) {
+        let propName: any = prop;
+        if (propName.startsWith('$')) {
+          propName = ctx.scope.get(propName);
+        }
+        base = base?.[propName];
+      }
+      let idx: any = idxToken;
+      if (idx.startsWith('$')) {
+        idx = ctx.scope.get(idx);
+      }
+      idx = Number(idx);
+      if (Array.isArray(base)) {
+        if (idx < 0) idx = base.length + idx;
+        base = base[idx];
+      } else {
+        base = undefined;
+        break;
+      }
+      token = token.slice(m[0].length);
+    }
+    if (token) {
+      let propName: any = token;
+      if (propName.startsWith('$')) {
+        propName = ctx.scope.get(propName);
+      }
+      base = base?.[propName];
+    }
+    current = base;
+  }
+  return current;
+}
+
+function isPath(value: string): boolean {
+  return value.startsWith('$') || value.startsWith('state');
+}
+
+export function evaluateExpr(node: any, ctx: EvalContext): any {
+  if (node === null || node === undefined) return undefined;
+  if (typeof node === 'string') {
+    return isPath(node) ? resolvePath(node, ctx) : node;
+  }
+  if (typeof node === 'number' || typeof node === 'boolean') return node;
+  if (Array.isArray(node)) return node.map((n) => evaluateExpr(n, ctx));
+
+  switch (node.kind) {
+    case NodeKind.Bool:
+      return node.value;
+    case NodeKind.Compare: {
+      const l = evaluateExpr(node.left, ctx);
+      const r = evaluateExpr(node.right, ctx);
+      switch (node.op) {
+        case '==':
+          return l === r;
+        case '!=':
+          return l !== r;
+        case '>':
+          return l > r;
+        case '>=':
+          return l >= r;
+        case '<':
+          return l < r;
+        case '<=':
+          return l <= r;
+      }
+      return false;
+    }
+    case NodeKind.Logic: {
+      if (node.op === 'not') {
+        return !Boolean(evaluateExpr(node.exprs[0], ctx));
+      } else if (node.op === 'and') {
+        for (const e of node.exprs) {
+          if (!evaluateExpr(e, ctx)) return false;
+        }
+        return true;
+      } else if (node.op === 'or') {
+        for (const e of node.exprs) {
+          if (evaluateExpr(e, ctx)) return true;
+        }
+        return false;
+      }
+      return false;
+    }
+    case NodeKind.Bind: {
+      const val = evaluateExpr(node.expr, ctx);
+      ctx.scope.set(node.name, val);
+      return val;
+    }
+    case NodeKind.Quantifier: {
+      const list = ctx.scope.get(node.variable);
+      if (!Array.isArray(list)) {
+        return node.quantifier === 'forall';
+      }
+      if (node.quantifier === 'exists') {
+        for (const item of list) {
+          ctx.scope.pushScope({ [node.variable]: item });
+          const res = evaluateExpr(node.expr, ctx);
+          ctx.scope.popScope();
+          if (res) return true;
+        }
+        return false;
+      } else {
+        for (const item of list) {
+          ctx.scope.pushScope({ [node.variable]: item });
+          const res = evaluateExpr(node.expr, ctx);
+          ctx.scope.popScope();
+          if (!res) return false;
+        }
+        return true;
+      }
+    }
+    default:
+      return undefined;
+  }
+}

--- a/src/engine/runtime/index.ts
+++ b/src/engine/runtime/index.ts
@@ -1,0 +1,3 @@
+export { Scope } from './scope';
+export type { EvalContext } from './evaluate';
+export { evaluateExpr } from './evaluate';

--- a/src/engine/runtime/scope.ts
+++ b/src/engine/runtime/scope.ts
@@ -1,0 +1,29 @@
+export class Scope {
+  private stack: Record<string, unknown>[] = [{}];
+
+  /** Push a new scope with optional initial variables */
+  pushScope(vars: Record<string, unknown> = {}): void {
+    this.stack.push({ ...vars });
+  }
+
+  /** Pop the current scope. Cannot pop the global scope. */
+  popScope(): void {
+    if (this.stack.length === 1) {
+      throw new Error('cannot pop global scope');
+    }
+    this.stack.pop();
+  }
+
+  /** Set a variable in the current scope */
+  set(name: string, value: unknown): void {
+    this.stack[this.stack.length - 1][name] = value;
+  }
+
+  /** Retrieve a variable value searching from inner to outer scopes */
+  get(name: string): unknown {
+    for (let i = this.stack.length - 1; i >= 0; i--) {
+      if (name in this.stack[i]) return this.stack[i][name];
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add `Scope` stack for variable bindings
- implement `evaluateExpr` with path resolution, comparisons, logic and quantifiers
- test variable binding, negative indices and quantifier evaluation

## Testing
- `pnpm test`
- `pnpm lint` *(fails: many lint errors)*
- `pnpm typecheck` *(fails: TS18046 in helpers/zones.util.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2d2f1ac8832baf97ee465fbf6190