### PR TITLE
feat: add action enumeration

### DIFF
--- a/src/engine/__test__/legal_actions.test.ts
+++ b/src/engine/__test__/legal_actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { legal_actions } from '../legal_actions';
+import { ActionNode, create_comparison_node, create_logic_node, NodeKind } from '../ast';
+import type { GameState } from '../../types';
+
+function baseState(): GameState {
+  return {
+    phase: 'main',
+    turn: 0,
+    seats: ['A', 'B'],
+    active_seat: 'A',
+    vars: {},
+    per_seat: {},
+    entities: {},
+    zones: {},
+    rng_state: '',
+    meta: { schema_version: 0, last_seq: 0, next_eid: 1 },
+  } as GameState;
+}
+
+const playMatchNode: ActionNode = {
+  kind: NodeKind.Action,
+  action: 'play_match',
+  require: create_logic_node('or', [
+    create_comparison_node('==', '$card.props.color', '$top.props.color'),
+    create_comparison_node('==', '$card.props.num', '$top.props.num'),
+  ]),
+  input: { type: 'object', properties: { card_id: { type: 'string' } }, required: ['card_id'] },
+};
+
+const drawOneNode: ActionNode = { kind: NodeKind.Action, action: 'draw_one' };
+
+describe('legal_actions enumeration', () => {
+  it('scenario A: multiple matching cards yield multiple play_match actions', () => {
+    const gs = baseState();
+    gs.entities = {
+      c1: { entity_type: 'card', props: { color: 'red', num: 1 } },
+      c2: { entity_type: 'card', props: { color: 'red', num: 2 } },
+      c3: { entity_type: 'card', props: { color: 'blue', num: 3 } },
+      t0: { entity_type: 'card', props: { color: 'red', num: 5 } },
+    } as any;
+    gs.zones = {
+      hand: { instances: { A: { kind: 'stack', items: ['c1', 'c2', 'c3'] } } },
+      discard_pile: { instances: { _: { kind: 'stack', items: ['t0'] } } },
+    } as any;
+
+    const calls = legal_actions({ actions: [playMatchNode, drawOneNode], game_state: gs, by: 'A' });
+    const matches = calls.filter((c) => c.action === 'play_match');
+    expect(matches.map((m) => (m.payload as any).card_id).sort()).toEqual(['c1', 'c2']);
+  });
+
+  it('scenario B: no matching cards yields only draw_one', () => {
+    const gs = baseState();
+    gs.entities = {
+      c1: { entity_type: 'card', props: { color: 'green', num: 1 } },
+      c2: { entity_type: 'card', props: { color: 'yellow', num: 2 } },
+      t0: { entity_type: 'card', props: { color: 'red', num: 5 } },
+    } as any;
+    gs.zones = {
+      hand: { instances: { A: { kind: 'stack', items: ['c1', 'c2'] } } },
+      discard_pile: { instances: { _: { kind: 'stack', items: ['t0'] } } },
+    } as any;
+
+    const calls = legal_actions({ actions: [playMatchNode, drawOneNode], game_state: gs, by: 'A' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].action).toBe('draw_one');
+  });
+});
+

--- a/src/engine/legal_actions.ts
+++ b/src/engine/legal_actions.ts
@@ -1,0 +1,70 @@
+import type { GameState } from "../types";
+import type { ActionNode } from "./ast";
+import { evaluate_expr } from "./runtime/evaluate";
+import { Scope } from "./runtime/scope";
+
+export type GeneratedAction = { action: string; by: string; payload?: Record<string, unknown> };
+
+/**
+ * Enumerate possible action calls from action nodes under current game state.
+ * - Supports simple enumeration over a player's hand when `card_id` is required.
+ * - Applies require expressions as a second pass filter after enumeration.
+ * - Uses `maxGeneratedActions` to cap output to avoid explosion.
+ */
+export function legal_actions(args: {
+  actions: ActionNode[];
+  game_state: GameState;
+  by: string;
+  maxGeneratedActions?: number;
+}): GeneratedAction[] {
+  const { actions, game_state, by } = args;
+  const cap =
+    typeof args.maxGeneratedActions === "number" && args.maxGeneratedActions > 0
+      ? args.maxGeneratedActions
+      : Infinity;
+
+  const out: GeneratedAction[] = [];
+
+  const zones: any = game_state.zones as any;
+  const hand: string[] =
+    zones?.hand?.instances?.[by]?.items && Array.isArray(zones.hand.instances[by].items)
+      ? [...zones.hand.instances[by].items]
+      : [];
+
+  const discardItems: string[] =
+    zones?.discard_pile?.instances?._?.items && Array.isArray(zones.discard_pile.instances._.items)
+      ? zones.discard_pile.instances._.items
+      : [];
+  const topEntity =
+    discardItems.length > 0 ? (game_state.entities as any)[discardItems[0]] : undefined;
+
+  for (const node of actions) {
+    if (node.input && (node.input as any).properties?.card_id) {
+      for (const card_id of hand) {
+        const payload = { card_id } as Record<string, unknown>;
+        const scope = new Scope();
+        scope.set_var("$card_id", card_id);
+        scope.set_var("$card", (game_state.entities as any)[card_id]);
+        scope.set_var("$top", topEntity);
+        const ctx = { state: game_state, scope } as const;
+        const ok = node.require ? Boolean(evaluate_expr(node.require, ctx)) : true;
+        if (ok) {
+          out.push({ action: node.action, by, payload });
+          if (out.length >= cap) return out;
+        }
+      }
+    } else {
+      const scope = new Scope();
+      scope.set_var("$top", topEntity);
+      const ctx = { state: game_state, scope } as const;
+      const ok = node.require ? Boolean(evaluate_expr(node.require, ctx)) : true;
+      if (ok) {
+        out.push({ action: node.action, by, payload: undefined });
+        if (out.length >= cap) return out;
+      }
+    }
+  }
+
+  return out;
+}
+


### PR DESCRIPTION
## Summary
- add `legal_actions` enumerator to expand card actions from state
- cover enumeration scenarios where cards match or not

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad54777480832b9b0650e60367fe7d